### PR TITLE
Fixed #2: Syntax checking with syntastic

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is filetype support for [Crystal programming language](http://crystal-lang.
 - Syntax highlight
 - Indentation (Using Ruby's indentation rule yet)
 - vim-matchit support
+- Syntax check (Using [Syntastic](https://github.com/scrooloose/syntastic))
 
 ![screenshot](https://dl.dropboxusercontent.com/u/2753138/crystal.png)
 

--- a/plugin/crystal.vim
+++ b/plugin/crystal.vim
@@ -1,0 +1,25 @@
+" Vim syntastic plugin helper
+" Language:     Crystal
+" Author:       Vitalii Elenhaupt<velenhaupt@gmail.com>
+
+if exists('g:loaded_syntastic_rust_filetype')
+  finish
+endif
+
+let g:loaded_syntastic_rust_filetype = 1
+let s:save_cpo = &cpo
+set cpo&vim
+
+" This is to let Syntastic know about the Crystal filetype.
+" It enables tab completion for the 'SyntasticInfo' command.
+" (This does not actually register the syntax checker.)
+" https://github.com/scrooloose/syntastic/wiki/Syntax-Checker-Guide#external
+if exists('g:syntastic_extra_filetypes')
+  call add(g:syntastic_extra_filetypes, 'crystal')
+else
+  let g:syntastic_extra_filetypes = ['crystal']
+end
+
+
+let &cpo = s:save_cpo
+unlet s:save_cpo

--- a/plugin/crystal.vim
+++ b/plugin/crystal.vim
@@ -2,11 +2,11 @@
 " Language:     Crystal
 " Author:       Vitalii Elenhaupt<velenhaupt@gmail.com>
 
-if exists('g:loaded_syntastic_rust_filetype')
+if exists('g:loaded_syntastic_crystal_filetype')
   finish
 endif
 
-let g:loaded_syntastic_rust_filetype = 1
+let g:loaded_syntastic_crystal_filetype = 1
 let s:save_cpo = &cpo
 set cpo&vim
 

--- a/syntax_checkers/crystal/crystal.vim
+++ b/syntax_checkers/crystal/crystal.vim
@@ -18,9 +18,8 @@ function! SyntaxCheckers_crystal_crystal_GetLocList() dict
   let makeprg = self.makeprgBuild({ 'args': 'run --no-build --no-color' })
 
   let errorformat =
+    \ '%ESyntax error in line %l: %m,'.
     \ '%ESyntax error in %f:%l: %m,'.
-    \ '%C%p^,'.
-    \ '%-C%.%#,'.
     \ '%EError in %f:%l: %m,'.
     \ '%C%p^,'.
     \ '%-C%.%#'

--- a/syntax_checkers/crystal/crystal.vim
+++ b/syntax_checkers/crystal/crystal.vim
@@ -1,0 +1,33 @@
+" Vim syntastic plugin
+" Language:     Crystal
+" Author:       Vitalii Elenhaupt<velenhaupt@gmail.com>
+"
+" See for details on how to add an external Syntastic checker:
+" https://github.com/scrooloose/syntastic/wiki/Syntax-Checker-Guide#external
+
+if exists('g:loaded_syntastic_crystal_crystal_checker')
+  finish
+endif
+
+let g:loaded_syntastic_crystal_crystal_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_crystal_crystal_GetLocList() dict
+  let makeprg = self.makeprgBuild({ 'args': 'run --no-build --no-color' })
+
+  let errorformat = ''
+
+  return SyntasticMake({
+    \ 'makeprg': makeprg,
+    \ 'errorformat': errorformat })
+
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+            \ 'filetype': 'crystal',
+            \ 'name': 'crystal' })
+
+let &cpo = s:save_cpo
+unlet s:save_cpo

--- a/syntax_checkers/crystal/crystal.vim
+++ b/syntax_checkers/crystal/crystal.vim
@@ -17,7 +17,13 @@ set cpo&vim
 function! SyntaxCheckers_crystal_crystal_GetLocList() dict
   let makeprg = self.makeprgBuild({ 'args': 'run --no-build --no-color' })
 
-  let errorformat = ''
+  let errorformat =
+    \ '%ESyntax error in %f:%l: %m,'.
+    \ '%C%p^,'.
+    \ '%-C%.%#,'.
+    \ '%EError in %f:%l: %m,'.
+    \ '%C%p^,'.
+    \ '%-C%.%#'
 
   return SyntasticMake({
     \ 'makeprg': makeprg,
@@ -26,8 +32,8 @@ function! SyntaxCheckers_crystal_crystal_GetLocList() dict
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({
-            \ 'filetype': 'crystal',
-            \ 'name': 'crystal' })
+  \ 'filetype': 'crystal',
+  \ 'name': 'crystal' })
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
![dd675f1987b842bf1668a2898faed114](https://cloud.githubusercontent.com/assets/3624712/7977640/1373fc46-0a95-11e5-8c12-c6f19f752cc5.png)
1. Nothing will happen if Syntastic not installed.
2. Nothing will happen if crystal not installed.
3. Currently it parses three types of message from crystal compiler:
   
   ``` sh
   Syntax error in line...
   ```
   
   ``` sh
   Syntax error in ...
   ```
   
   ``` sh
   Error in ...
   ```
   
   Otherwise Syntastic will not highlight  line and provide balloon, only "Syntax: line(..)" in status bar will be shown.
   
   Let me know if you are aware about other messages from crystal compiler.
