### PR TITLE
Fix syntastic crystal run args

### DIFF
--- a/syntax_checkers/crystal/crystal.vim
+++ b/syntax_checkers/crystal/crystal.vim
@@ -15,7 +15,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_crystal_crystal_GetLocList() dict
-  let makeprg = self.makeprgBuild({ 'args': 'run --no-build --no-color' })
+  let makeprg = self.makeprgBuild({ 'args': 'run --no-codegen --no-color' })
 
   let errorformat =
     \ '%ESyntax error in line %l: %m,'.


### PR DESCRIPTION
`--no-build` has been renamed to `--no-codegen`.

```
crystal --version
Crystal 0.7.6 [eb13f75] (Thu Aug 13 22:00:15 UTC 2015)

crystal run --help
Usage: crystal run [options] [programfile] [--] [arguments]

Options:
    -d, --debug                      Add symbolic debug info
    -D FLAG, --define FLAG           Define a compile-time flag
    --emit [asm|llvm-bc|llvm-ir|obj] Comma separated list of types of output for the compiler to emit
    -h, --help                       Show this message
    --ll                             Dump ll to .crystal directory
    --link-flags FLAGS               Additional flags to pass to the linker
    --mcpu CPU                       Target specific cpu type
    --no-color                       Disable colored output
    --no-codegen                     Don't do code generation
    -o                               Output filename
    --prelude                        Use given file as prelude
    --release                        Compile in release mode
    -s, --stats                      Enable statistics output
    --single-module                  Generate a single LLVM module
    --threads                        Maximum number of threads to use
    --verbose                        Display executed commands
```
