### PR TITLE
Set errorformat for use in quickfix window

### DIFF
--- a/ftplugin/crystal.vim
+++ b/ftplugin/crystal.vim
@@ -29,6 +29,14 @@ endif
 setlocal comments=:#
 setlocal commentstring=#\ %s
 
+" Set format for quickfix window
+setlocal errorformat=
+  \%ESyntax\ error\ in\ line\ %l:\ %m,
+  \%ESyntax\ error\ in\ %f:%l:\ %m,
+  \%EError\ in\ %f:%l:\ %m,
+  \%C%p^,
+  \%-C%.%#
+
 let &cpo = s:save_cpo
 unlet s:save_cpo
 


### PR DESCRIPTION
Seems like it's necessary to repeat the errorformat used in the
Syntastic plugin, because the option assignment needs to have the spaces
escaped.

Maybe there's a better way to do this so that the string isn't repeated twice?
