### PR TITLE
syntax_checker: don't pass entrypoint if it's the same as the file

### DIFF
--- a/syntax_checkers/crystal/crystal.vim
+++ b/syntax_checkers/crystal/crystal.vim
@@ -19,7 +19,7 @@ function! SyntaxCheckers_crystal_crystal_GetLocList() dict
     let entrypoint = crystal_lang#entrypoint_for(file)
     let makeprg = self.makeprgBuild({
                 \   'args': 'run --no-codegen --no-color',
-                \   'post_args': entrypoint
+                \   'post_args': entrypoint ==# file ? '' : entrypoint
                 \ })
     let errorformat =
                 \ '%ESyntax error in line %l: %m,'.


### PR DESCRIPTION
Note for review: I have only tested this on limited use cases (the one described in #34) and don't currently have the ability to test with cases where an entrypoint does differ (with spec directory). I _imagine_ this will work for both the cases, but I couldn't be 100% sure on it.

Original commit message below:

---

Passing the same file twice to `crystal --no-codegen` will cause it to
emit errors in certain situations (such as for `alias`), so we should
check whether the entrypoint is the same as the file, and if it is let's
not pass the duplicate argument.

Fixes #34
