### PR TITLE
Syntastic checker for Ameba linter

### DIFF
--- a/syntax_checkers/crystal/ameba.vim
+++ b/syntax_checkers/crystal/ameba.vim
@@ -1,0 +1,34 @@
+" Vim syntastic plugin
+" Language:     Crystal
+" Author:       Vitalii Elenhaupt<velenhaupt@gmail.com>
+"
+" See for details on how to add an external Syntastic checker:
+" https://github.com/scrooloose/syntastic/wiki/Syntax-Checker-Guide#external
+
+if exists('g:loaded_syntastic_crystal_ameba_checker')
+    finish
+endif
+
+let g:loaded_syntastic_crystal_ameba_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_crystal_ameba_GetLocList() dict
+    let makeprg = self.makeprgBuild({'args': '--format flycheck'})
+
+    let errorformat = '%f:%l:%c: %t: %m'
+    let loclist = SyntasticMake({
+                \ 'makeprg': makeprg,
+                \ 'errorformat': errorformat})
+
+    return loclist
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+            \   'filetype': 'crystal',
+            \   'name': 'ameba'
+            \ })
+
+let &cpo = s:save_cpo
+unlet s:save_cpo


### PR DESCRIPTION
This change adds a Syntastic syntax checker for [Ameba](https://github.com/veelenga/ameba) linter and depends on [Ameba#27](https://github.com/veelenga/ameba/pull/27) PR.

Would you like to have this as a part of vim-crystal?

<img width="717" alt="screen shot 2017-12-08 at 11 00 04 pm" src="https://user-images.githubusercontent.com/3624712/33785022-f2ff68fa-dc6b-11e7-92fb-aa7bde44a8a0.png">

![kapture 2017-12-08 at 23 07 08](https://user-images.githubusercontent.com/3624712/33785164-8d734bae-dc6c-11e7-9543-19a990efdeb7.gif)

![kapture 2017-12-08 at 23 11 13](https://user-images.githubusercontent.com/3624712/33785314-2109e756-dc6d-11e7-90fb-95d484cfa4c2.gif)

