### PR TITLE
Allow to specify the spec file to use

### DIFF
--- a/autoload/crystal_lang.vim
+++ b/autoload/crystal_lang.vim
@@ -51,9 +51,9 @@ function! crystal_lang#entrypoint_for(file_path) abort
         return a:file_path
     endif
 
-    let spec_for_file = get(b:, 'crystal_spec_file', get(g:, 'crystal_spec_file', ''))
-    if spec_for_file !=# ''
-      let require_spec_str = './' . spec_for_file
+    let required_spec_path = get(b:, 'crystal_required_spec_path', get(g:, 'crystal_required_spec_path', ''))
+    if required_spec_path !=# ''
+      let require_spec_str = './' . required_spec_path
     else
       let require_spec_str = './spec/**'
     endif

--- a/autoload/crystal_lang.vim
+++ b/autoload/crystal_lang.vim
@@ -51,10 +51,17 @@ function! crystal_lang#entrypoint_for(file_path) abort
         return a:file_path
     endif
 
+    let spec_for_file = get(b:, 'crystal_spec_file', get(g:, 'crystal_spec_file', ''))
+    if spec_for_file !=# ''
+      let require_spec_str = './' . spec_for_file
+    else
+      let require_spec_str = './spec/**'
+    endif
+
     let temp_name = root_dir . '/__vim-crystal-temporary-entrypoint-' . fnamemodify(a:file_path, ':t')
     let contents = [
                 \   'require "spec"',
-                \   'require "./spec/**"',
+                \   'require "' . require_spec_str . '"',
                 \   printf('require "./%s"', fnamemodify(a:file_path, ':p')[strlen(root_dir)+1 : ])
                 \ ]
 


### PR DESCRIPTION
Fixes #66 

It'll check if there is a `b:crystal_spec_file`, then `g:crystal_spec_file`, then fallback to require all specs.