### PR TITLE
Syntax: avoid false positive highliting of #record

### DIFF
--- a/syntax/crystal.vim
+++ b/syntax/crystal.vim
@@ -288,7 +288,7 @@ if !exists('g:crystal_no_special_methods')
   syn match   crystalInclude   "\<include\>[?!]\@!" display
   syn keyword crystalInclude   extend require
   syn keyword crystalKeyword   caller typeof pointerof sizeof instance_sizeof
-  syn match   crystalRecord    "\<record\>[?!]\@!" display
+  syn match   crystalRecord    "\<record\%(\s\+\u\w*\)\@=" display
 endif
 
 " Macro


### PR DESCRIPTION
We don't want `record` to be highlighted in such cases, as `Foo.record`, or `record = 1`.
I'm not sure if this approach is the best one, but at least it does the job.