### PR TITLE
Fix some minor indent issues related to private/protected

### DIFF
--- a/indent/crystal.vim
+++ b/indent/crystal.vim
@@ -15,7 +15,7 @@ setlocal nosmartindent
 setlocal indentexpr=GetCrystalIndent(v:lnum)
 setlocal indentkeys=0{,0},0),0],!^F,o,O,e,:,.
 setlocal indentkeys+==end,=else,=elsif,=when,=ensure,=rescue,==begin,==end
-setlocal indentkeys+==private,=protected,=public
+setlocal indentkeys+==private,=protected
 
 " Only define the function once.
 if exists('*GetCrystalIndent')
@@ -47,12 +47,12 @@ let s:skip_expr =
 
 " Regex used for words that, at the start of a line, add a level of indent.
 let s:crystal_indent_keywords =
-      \ '^\s*\zs\<\%(module\|\%(private\s\+\)\=\%(abstract\s\+\)\=\%(class\|struct\)\|enum\|if' .
-      \ '\|for\|macro\|while\|until\|else\|elsif\|case\|when\|unless\|begin\|ensure\|rescue\|lib' .
-      \ '\|\%(protected\|private\)\=\s*def\):\@!\>' .
+      \ '^\s*\zs\<\%(\%(\%(private\|protected\)\s\+\)\=\%(abstract\s\+\)\=\%(class\|struct\|def\)' .
+      \ '\|if\|for\|while\|until\|else\|elsif\|case\|when\|unless\|begin\|ensure\|rescue' .
+      \ '\|\%(private\|protected\)\=\s*\%(def\|class\|struct\|module\|macro\|lib\|enum\)\):\@!\>' .
       \ '\|\%([=,*/%+-]\|<<\|>>\|:\s\)\s*\zs' .
       \ '\<\%(if\|for\|while\|until\|case\|unless\|begin\):\@!\>' .
-      \ '\|{%\s*\<\%(if\|for\|while\|until\|lib\|case\|unless\|begin\|else\|elsif\|when\)'
+      \ '\|{%\s*\<\%(if\|for\|while\|until\|case\|unless\|begin\|else\|elsif\|when\)'
 
 " Regex used for words that, at the start of a line, remove a level of indent.
 let s:crystal_deindent_keywords =
@@ -62,10 +62,11 @@ let s:crystal_deindent_keywords =
 " Regex that defines the start-match for the 'end' keyword.
 " TODO: the do here should be restricted somewhat (only at end of line)?
 let s:end_start_regex =
-      \ '{%\s*\<\%(if\|for\|while\|until\|unless\|begin\|lib\)\>\|' .
+      \ '{%\s*\<\%(if\|for\|while\|until\|unless\|begin\)\>\|' .
       \ '\C\%(^\s*\|[=,*/%+\-|;{]\|<<\|>>\|:\s\)\s*\zs' .
-      \ '\<\%(module\|\%(private\s\+\)\=\%(abstract\s\+\)\=\%(class\|struct\)\|enum\|macro\|if\|for\|while\|until\|case\|unless\|begin\|lib' .
-      \ '\|\%(protected\|private\)\=\s*def\):\@!\>' .
+      \ '\<\%(\%(\%(private\|protected\)\s\+\)\=\%(abstract\s\+\)\=\%(class\|struct\|def\)' .
+      \ '\|if\|for\|while\|until\|case\|unless\|begin' .
+      \ '\|\%(private\|protected\)\=\s*\%(lib\|enum\|macro\|module\)\):\@!\>' .
       \ '\|\%(^\|[^.:@$]\)\@<=\<do:\@!\>'
 
 " Regex that defines the middle-match for the 'end' keyword.
@@ -120,7 +121,7 @@ let s:block_continuation_regex = '^\s*[^])}\t ].*'.s:block_regex
 let s:leading_operator_regex = '^\s*[.]'
 
 " Regex that describes all indent access modifiers
-let s:access_modifier_regex = '\C^\s*\%(public\|protected\|private\)\s*\%(#.*\)\=$'
+let s:access_modifier_regex = '\C^\s*\%(protected\|private\)\s*\%(#.*\)\=$'
 
 " 2. Auxiliary Functions {{{1
 " ======================

--- a/indent/crystal.vim
+++ b/indent/crystal.vim
@@ -48,7 +48,7 @@ let s:skip_expr =
 " Regex used for words that, at the start of a line, add a level of indent.
 let s:crystal_indent_keywords =
       \ '^\s*\zs\<\%(\%(\%(private\|protected\)\s\+\)\=\%(abstract\s\+\)\=\%(class\|struct\)' .
-      \ '\|if\|for\|while\|until\|else\|elsif\|case\|when\|unless\|begin\|ensure\|rescue' .
+      \ '\|if\|for\|while\|until\|else\|elsif\|case\|when\|unless\|begin\|ensure\|rescue\|union' .
       \ '\|\%(private\|protected\)\=\s*\%(def\|class\|struct\|module\|macro\|lib\|enum\)\):\@!\>' .
       \ '\|\%([=,*/%+-]\|<<\|>>\|:\s\)\s*\zs' .
       \ '\<\%(if\|for\|while\|until\|case\|unless\|begin\):\@!\>' .
@@ -65,7 +65,7 @@ let s:end_start_regex =
       \ '{%\s*\<\%(if\|for\|while\|until\|unless\|begin\)\>\|' .
       \ '\C\%(^\s*\|[=,*/%+\-|;{]\|<<\|>>\|:\s\)\s*\zs' .
       \ '\<\%(\%(\%(private\|protected\)\s\+\)\=\%(abstract\s\+\)\=\%(class\|struct\)' .
-      \ '\|if\|for\|while\|until\|case\|unless\|begin' .
+      \ '\|if\|for\|while\|until\|case\|unless\|begin\|union' .
       \ '\|\%(private\|protected\)\=\s*\%(def\|lib\|enum\|macro\|module\)\):\@!\>' .
       \ '\|\%(^\|[^.:@$]\)\@<=\<do:\@!\>'
 

--- a/indent/crystal.vim
+++ b/indent/crystal.vim
@@ -47,7 +47,7 @@ let s:skip_expr =
 
 " Regex used for words that, at the start of a line, add a level of indent.
 let s:crystal_indent_keywords =
-      \ '^\s*\zs\<\%(\%(\%(private\|protected\)\s\+\)\=\%(abstract\s\+\)\=\%(class\|struct\|def\)' .
+      \ '^\s*\zs\<\%(\%(\%(private\|protected\)\s\+\)\=\%(abstract\s\+\)\=\%(class\|struct\)' .
       \ '\|if\|for\|while\|until\|else\|elsif\|case\|when\|unless\|begin\|ensure\|rescue' .
       \ '\|\%(private\|protected\)\=\s*\%(def\|class\|struct\|module\|macro\|lib\|enum\)\):\@!\>' .
       \ '\|\%([=,*/%+-]\|<<\|>>\|:\s\)\s*\zs' .
@@ -64,9 +64,9 @@ let s:crystal_deindent_keywords =
 let s:end_start_regex =
       \ '{%\s*\<\%(if\|for\|while\|until\|unless\|begin\)\>\|' .
       \ '\C\%(^\s*\|[=,*/%+\-|;{]\|<<\|>>\|:\s\)\s*\zs' .
-      \ '\<\%(\%(\%(private\|protected\)\s\+\)\=\%(abstract\s\+\)\=\%(class\|struct\|def\)' .
+      \ '\<\%(\%(\%(private\|protected\)\s\+\)\=\%(abstract\s\+\)\=\%(class\|struct\)' .
       \ '\|if\|for\|while\|until\|case\|unless\|begin' .
-      \ '\|\%(private\|protected\)\=\s*\%(lib\|enum\|macro\|module\)\):\@!\>' .
+      \ '\|\%(private\|protected\)\=\s*\%(def\|lib\|enum\|macro\|module\)\):\@!\>' .
       \ '\|\%(^\|[^.:@$]\)\@<=\<do:\@!\>'
 
 " Regex that defines the middle-match for the 'end' keyword.


### PR DESCRIPTION
There are some small problems with how vim-crystal is indenting lines that begin with `private` or `protected`.

Some examples of things that are not indenting properly:

```crystal
module Test
  private macro foo(x)
    puts {{x}}
  end

  private def bar
    "foo"
  end

  private lib LibFoo
    fun foo
  end

  private abstract class Foo
    abstract def foo
    abstract def bar
  end

  private enum Baz
    A
    B
    C
  end
end
```

This PR should hopefully fix these. I also removed references to `public`, since it is not allowed in Crystal.