### PR TITLE
Added the html filetype to ecr to also get html syntax highlighting

### DIFF
--- a/ftdetect/crystal.vim
+++ b/ftdetect/crystal.vim
@@ -1,4 +1,4 @@
 " vint: -ProhibitAutocmdWithNoGroup
 autocmd BufNewFile,BufReadPost *.cr setlocal filetype=crystal
 autocmd BufNewFile,BufReadPost Projectfile setlocal filetype=crystal
-autocmd BufNewFile,BufReadPost *.ecr setlocal filetype=eruby
+autocmd BufNewFile,BufReadPost *.ecr setlocal filetype=eruby.html


### PR DESCRIPTION
Hi there! Thank you so much for the hard work on this plugin, it has been great so far.
I was going to create an issue for this, but it seemed small enough that I might as well start the discussion in a PR anyway. 

When editing a `*.ecr` file in a Kemal project, the html was not being highlighted as well. I suspect this was because the filetype was only being set to `eruby` in the `ftdetect`. This meant the eruby regions (`<% %>`) were being highlighted, but the html was not. This change would allow full syntax highlighting in ecr files.

Please let me know if there are any issues with this and I will do my best to fix. :) 