### PR TITLE
Add eCrystal

### DIFF
--- a/autoload/crystal/indent.vim
+++ b/autoload/crystal/indent.vim
@@ -1,0 +1,327 @@
+" Variables {{{1
+" =========
+
+" Regex of syntax group names that are strings or characters.
+const crystal#indent#syng_string =
+      \ '\<crystal\%(String\|Interpolation\|NoInterpolation\|StringEscape\|CharLiteral\|ASCIICode\)\>'
+
+" Regex of syntax group names that are strings, characters, symbols,
+" regexps, or comments.
+const crystal#indent#syng_strcom =
+      \ crystal#indent#syng_string.'\|' .
+      \ '\<crystal\%(Regexp\|RegexpEscape\|Symbol\|Comment\)\>'
+
+" Expression used to check whether we should skip a match with searchpair().
+const crystal#indent#skip_expr =
+      \ 'synIDattr(synID(line("."), col("."), 1), "name") =~# "'.crystal#indent#syng_strcom.'"'
+
+" Regex for the start of a line:
+" start of line + whitespace + optional opening macro delimiter
+const crystal#indent#sol = '^\s*\zs\%(\\\={%\s*\)\='
+
+" Regex for the end of a line:
+" whitespace + optional closing macro delimiter + whitespace +
+" optional comment + end of line
+const crystal#indent#eol = '\s*\%(%}\)\=\ze\s*\%(#.*\)\=$'
+
+" Regex that defines the start-match for the 'end' keyword.
+" NOTE: This *should* properly match the 'do' only at the end of the
+" line
+const crystal#indent#end_start_regex =
+      \ crystal#indent#sol .
+      \ '\%(' .
+      \ '\%(\<\%(private\|protected\)\s\+\)\=' .
+      \ '\%(\<\%(abstract\s\+\)\=\%(class\|struct\)\>\|\<\%(def\|module\|macro\|lib\|enum\)\>\)' .
+      \ '\|' .
+      \ '\<\%(if\|unless\|while\|until\|case\|begin\|for\|union\)\>' .
+      \ '\)' .
+      \ '\|' .
+      \ '.\{-}\zs\<do\s*\%(|.*|\)\='.crystal#indent#eol
+
+" Regex that defines the middle-match for the 'end' keyword.
+const crystal#indent#end_middle_regex =
+      \ crystal#indent#sol .
+      \ '\<\%(else\|elsif\|rescue\|ensure\|when\)\>'
+
+" Regex that defines the end-match for the 'end' keyword.
+const crystal#indent#end_end_regex =
+      \ crystal#indent#sol .
+      \ '\<end\>'
+
+" Regex used for words that add a level of indent.
+const crystal#indent#crystal_indent_keywords =
+      \ crystal#indent#end_start_regex .
+      \ '\|' .
+      \ crystal#indent#end_middle_regex
+
+" Regex used for words that remove a level of indent.
+const crystal#indent#crystal_deindent_keywords =
+      \ crystal#indent#end_middle_regex .
+      \ '\|' .
+      \ crystal#indent#end_end_regex
+
+" Regex that defines continuation lines, not including (, {, or [.
+const crystal#indent#non_bracket_continuation_regex = '\%([\\.,:*/%+]\|\<and\|\<or\|\%(<%\)\@<![=-]\|\W[|&?]\|||\|&&\)\s*\%(#.*\)\=$'
+
+" Regex that defines continuation lines.
+const crystal#indent#continuation_regex =
+      \ '\%(%\@<![({[\\.,:*/%+]\|\<and\|\<or\|\%(<%\)\@<![=-]\|\W[|&?]\|||\|&&\)\s*\%(#.*\)\=$'
+
+" Regex that defines continuable keywords
+const crystal#indent#continuable_regex =
+      \ '\%(^\s*\|[=,*/%+\-|;{]\|<<\|>>\|:\s\)\s*\zs' .
+      \ '\<\%(if\|for\|while\|until\|unless\):\@!\>'
+
+" Regex that defines bracket continuations
+const crystal#indent#bracket_continuation_regex = '%\@<!\%([({[]\)\s*\%(#.*\)\=$'
+
+" Regex that defines end of bracket continuation followed by another continuation
+const crystal#indent#bracket_switch_continuation_regex = '^\([^(]\+\zs).\+\)\+'.crystal#indent#continuation_regex
+
+" Regex that defines the first part of a splat pattern
+const crystal#indent#splat_regex = '[[,(]\s*\*\s*\%(#.*\)\=$'
+
+" Regex that defines blocks.
+"
+" Note that there's a slight problem with this regex and crystal#indent#continuation_regex.
+" Code like this will be matched by both:
+"
+"   method_call do |(a, b)|
+"
+" The reason is that the pipe matches a hanging "|" operator.
+"
+const crystal#indent#block_regex =
+      \ '\%(\<do:\@!\>\|%\@<!{\)\s*\%(|\s*(*\s*\%([*@&]\=\h\w*,\=\s*\)\%(,\s*(*\s*[*@&]\=\h\w*\s*)*\s*\)*|\)\=\s*\%(%}\)\=\s*\%(#.*\)\=$'
+
+const crystal#indent#block_continuation_regex = '^\s*[^])}\t ].*'.crystal#indent#block_regex
+
+" Regex that describes a leading operator (only a method call's dot for now)
+const crystal#indent#leading_operator_regex = '^\s*[.]'
+
+" Auxiliary Functions {{{1
+" ===================
+
+" Check if the character at lnum:col is inside a string, comment, or is ascii.
+function crystal#indent#IsInStringOrComment(lnum, col)
+  return synIDattr(synID(a:lnum, a:col, 1), 'name') =~# g:crystal#indent#syng_strcom
+endfunction
+
+" Check if the character at lnum:col is inside a string or character.
+function crystal#indent#IsInString(lnum, col)
+  return synIDattr(synID(a:lnum, a:col, 1), 'name') =~# g:crystal#indent#syng_string
+endfunction
+
+" Check if the character at lnum:col is inside a string delimiter
+function crystal#indent#IsInStringDelimiter(lnum, col)
+  return synIDattr(synID(a:lnum, a:col, 1), 'name') ==# 'crystalStringDelimiter'
+endfunction
+
+" Find line above 'lnum' that isn't empty, in a comment, or in a string.
+function crystal#indent#PrevNonBlankNonString(lnum)
+  let lnum = prevnonblank(a:lnum)
+
+  while lnum > 0
+    let line = getline(lnum)
+    let start = match(line, '\S')
+
+    if !crystal#indent#IsInStringOrComment(lnum, start + 1)
+      break
+    endif
+
+    let lnum = prevnonblank(lnum - 1)
+  endwhile
+
+  return lnum
+endfunction
+
+" Find line above 'lnum' that started the continuation 'lnum' may be part of.
+function crystal#indent#GetMSL(lnum)
+  " Start on the line we're at and use its indent.
+  let msl = a:lnum
+  let msl_body = getline(msl)
+  let lnum = crystal#indent#PrevNonBlankNonString(a:lnum - 1)
+
+  while lnum > 0
+    " If we have a continuation line, or we're in a string, use line as MSL.
+    " Otherwise, terminate search as we have found our MSL already.
+    let line = getline(lnum)
+
+    if crystal#indent#Match(msl, g:crystal#indent#leading_operator_regex)
+      " If the current line starts with a leading operator, keep its indent
+      " and keep looking for an MSL.
+      let msl = lnum
+    elseif crystal#indent#Match(lnum, g:crystal#indent#splat_regex)
+      " If the above line looks like the "*" of a splat, use the current one's
+      " indentation.
+      "
+      " Example:
+      "   Hash[*
+      "     method_call do
+      "       something
+      "
+      return msl
+    elseif crystal#indent#Match(lnum, g:crystal#indent#non_bracket_continuation_regex) &&
+          \ crystal#indent#Match(msl, g:crystal#indent#non_bracket_continuation_regex)
+      " If the current line is a non-bracket continuation and so is the
+      " previous one, keep its indent and continue looking for an MSL.
+      "
+      " Example:
+      "   method_call one,
+      "     two,
+      "     three
+      "
+      let msl = lnum
+    elseif crystal#indent#Match(lnum, g:crystal#indent#non_bracket_continuation_regex) &&
+          \ (
+          \ crystal#indent#Match(msl, g:crystal#indent#bracket_continuation_regex) ||
+          \ crystal#indent#Match(msl, g:crystal#indent#block_continuation_regex)
+          \ )
+      " If the current line is a bracket continuation or a block-starter, but
+      " the previous is a non-bracket one, respect the previous' indentation,
+      " and stop here.
+      "
+      " Example:
+      "   method_call one,
+      "     two {
+      "     three
+      "
+      return lnum
+    elseif crystal#indent#Match(lnum, g:crystal#indent#bracket_continuation_regex) &&
+          \ (
+          \ crystal#indent#Match(msl, g:crystal#indent#bracket_continuation_regex) ||
+          \ crystal#indent#Match(msl, g:crystal#indent#block_continuation_regex)
+          \ )
+      " If both lines are bracket continuations (the current may also be a
+      " block-starter), use the current one's and stop here
+      "
+      " Example:
+      "   method_call(
+      "     other_method_call(
+      "       foo
+      return msl
+    elseif crystal#indent#Match(lnum, g:crystal#indent#block_regex) &&
+          \ !crystal#indent#Match(msl, g:crystal#indent#continuation_regex) &&
+          \ !crystal#indent#Match(msl, g:crystal#indent#block_continuation_regex)
+      " If the previous line is a block-starter and the current one is
+      " mostly ordinary, use the current one as the MSL.
+      "
+      " Example:
+      "   method_call do
+      "     something
+      "     something_else
+      return msl
+    else
+      let col = match(line, g:crystal#indent#continuation_regex) + 1
+
+      if (col > 0 && !crystal#indent#IsInStringOrComment(lnum, col))
+            \ || crystal#indent#IsInString(lnum, strlen(line))
+        let msl = lnum
+      else
+        break
+      endif
+    endif
+
+    let msl_body = getline(msl)
+    let lnum = crystal#indent#PrevNonBlankNonString(lnum - 1)
+  endwhile
+
+  return msl
+endfunction
+
+" Check if line 'lnum' has more opening brackets than closing ones.
+function crystal#indent#ExtraBrackets(lnum)
+  let opening = {'parentheses': [], 'braces': [], 'brackets': []}
+  let closing = {'parentheses': [], 'braces': [], 'brackets': []}
+
+  let line = getline(a:lnum)
+  let pos  = match(line, '[][(){}]', 0)
+
+  " Save any encountered opening brackets, and remove them once a matching
+  " closing one has been found. If a closing bracket shows up that doesn't
+  " close anything, save it for later.
+  while pos != -1
+    if !crystal#indent#IsInStringOrComment(a:lnum, pos + 1)
+      if line[pos] ==# '('
+        call add(opening.parentheses, {'type': '(', 'pos': pos})
+      elseif line[pos] ==# ')'
+        if empty(opening.parentheses)
+          call add(closing.parentheses, {'type': ')', 'pos': pos})
+        else
+          let opening.parentheses = opening.parentheses[0:-2]
+        endif
+      elseif line[pos] ==# '{'
+        call add(opening.braces, {'type': '{', 'pos': pos})
+      elseif line[pos] ==# '}'
+        if empty(opening.braces)
+          call add(closing.braces, {'type': '}', 'pos': pos})
+        else
+          let opening.braces = opening.braces[0:-2]
+        endif
+      elseif line[pos] ==# '['
+        call add(opening.brackets, {'type': '[', 'pos': pos})
+      elseif line[pos] ==# ']'
+        if empty(opening.brackets)
+          call add(closing.brackets, {'type': ']', 'pos': pos})
+        else
+          let opening.brackets = opening.brackets[0:-2]
+        endif
+      endif
+    endif
+
+    let pos = match(line, '[][(){}]', pos + 1)
+  endwhile
+
+  " Find the rightmost brackets, since they're the ones that are important in
+  " both opening and closing cases
+  let rightmost_opening = {'type': '(', 'pos': -1}
+  let rightmost_closing = {'type': ')', 'pos': -1}
+
+  for opening in opening.parentheses + opening.braces + opening.brackets
+    if opening.pos > rightmost_opening.pos
+      let rightmost_opening = opening
+    endif
+  endfor
+
+  for closing in closing.parentheses + closing.braces + closing.brackets
+    if closing.pos > rightmost_closing.pos
+      let rightmost_closing = closing
+    endif
+  endfor
+
+  return [rightmost_opening, rightmost_closing]
+endfunction
+
+function crystal#indent#Match(lnum, regex)
+  let regex = '\C'.a:regex
+
+  let line = getline(a:lnum)
+  let col  = match(line, regex) + 1
+
+  while col && crystal#indent#IsInStringOrComment(a:lnum, col)
+    let col = match(line, regex, col) + 1
+  endwhile
+
+  return col
+endfunction
+
+" Locates the containing class/module/struct/enum/lib's definition line,
+" ignoring nested classes along the way.
+function crystal#indent#FindContainingClass()
+  let saved_position = getcurpos()
+
+  while searchpair(
+        \ g:crystal#indent#end_start_regex,
+        \ g:crystal#indent#end_middle_regex,
+        \ g:crystal#indent#end_end_regex,
+        \ 'bWz',
+        \ g:crystal#indent#skip_expr) > 0
+    if expand('<cword>') =~# '\<\%(class\|module\|struct\|enum\|lib\)\>'
+      let found_lnum = line('.')
+      call setpos('.', saved_position)
+      return found_lnum
+    endif
+  endwhile
+
+  call setpos('.', saved_position)
+  return 0
+endfunction

--- a/autoload/crystal/indent.vim
+++ b/autoload/crystal/indent.vim
@@ -2,33 +2,38 @@
 " =========
 
 " Regex of syntax group names that are strings or characters.
-const crystal#indent#syng_string =
+let g:crystal#indent#syng_string =
       \ '\<crystal\%(String\|Interpolation\|NoInterpolation\|StringEscape\|CharLiteral\|ASCIICode\)\>'
+lockvar g:crystal#indent#syng_string
 
 " Regex of syntax group names that are strings, characters, symbols,
 " regexps, or comments.
-const crystal#indent#syng_strcom =
-      \ crystal#indent#syng_string.'\|' .
+let g:crystal#indent#syng_strcom =
+      \ g:crystal#indent#syng_string.'\|' .
       \ '\<crystal\%(Regexp\|RegexpEscape\|Symbol\|Comment\)\>'
+lockvar g:crystal#indent#syng_strcom
 
 " Expression used to check whether we should skip a match with searchpair().
-const crystal#indent#skip_expr =
-      \ 'synIDattr(synID(line("."), col("."), 1), "name") =~# "'.crystal#indent#syng_strcom.'"'
+let g:crystal#indent#skip_expr =
+      \ 'synIDattr(synID(line("."), col("."), 1), "name") =~# "'.g:crystal#indent#syng_strcom.'"'
+lockvar g:crystal#indent#skip_expr
 
 " Regex for the start of a line:
 " start of line + whitespace + optional opening macro delimiter
-const crystal#indent#sol = '^\s*\zs\%(\\\={%\s*\)\='
+let g:crystal#indent#sol = '^\s*\zs\%(\\\={%\s*\)\='
+lockvar g:crystal#indent#sol
 
 " Regex for the end of a line:
 " whitespace + optional closing macro delimiter + whitespace +
 " optional comment + end of line
-const crystal#indent#eol = '\s*\%(%}\)\=\ze\s*\%(#.*\)\=$'
+let g:crystal#indent#eol = '\s*\%(%}\)\=\ze\s*\%(#.*\)\=$'
+lockvar g:crystal#indent#eol
 
 " Regex that defines the start-match for the 'end' keyword.
 " NOTE: This *should* properly match the 'do' only at the end of the
 " line
-const crystal#indent#end_start_regex =
-      \ crystal#indent#sol .
+let g:crystal#indent#end_start_regex =
+      \ g:crystal#indent#sol .
       \ '\%(' .
       \ '\%(\<\%(private\|protected\)\s\+\)\=' .
       \ '\%(\<\%(abstract\s\+\)\=\%(class\|struct\)\>\|\<\%(def\|module\|macro\|lib\|enum\)\>\)' .
@@ -36,50 +41,61 @@ const crystal#indent#end_start_regex =
       \ '\<\%(if\|unless\|while\|until\|case\|begin\|for\|union\)\>' .
       \ '\)' .
       \ '\|' .
-      \ '.\{-}\zs\<do\s*\%(|.*|\)\='.crystal#indent#eol
+      \ '.\{-}\zs\<do\s*\%(|.*|\)\='.g:crystal#indent#eol
+lockvar g:crystal#indent#end_start_regex
 
 " Regex that defines the middle-match for the 'end' keyword.
-const crystal#indent#end_middle_regex =
-      \ crystal#indent#sol .
+let g:crystal#indent#end_middle_regex =
+      \ g:crystal#indent#sol .
       \ '\<\%(else\|elsif\|rescue\|ensure\|when\)\>'
+lockvar g:crystal#indent#end_middle_regex
 
 " Regex that defines the end-match for the 'end' keyword.
-const crystal#indent#end_end_regex =
-      \ crystal#indent#sol .
+let g:crystal#indent#end_end_regex =
+      \ g:crystal#indent#sol .
       \ '\<end\>'
+lockvar g:crystal#indent#end_end_regex
 
 " Regex used for words that add a level of indent.
-const crystal#indent#crystal_indent_keywords =
-      \ crystal#indent#end_start_regex .
+let g:crystal#indent#crystal_indent_keywords =
+      \ g:crystal#indent#end_start_regex .
       \ '\|' .
-      \ crystal#indent#end_middle_regex
+      \ g:crystal#indent#end_middle_regex
+lockvar g:crystal#indent#crystal_indent_keywords
 
 " Regex used for words that remove a level of indent.
-const crystal#indent#crystal_deindent_keywords =
-      \ crystal#indent#end_middle_regex .
+let g:crystal#indent#crystal_deindent_keywords =
+      \ g:crystal#indent#end_middle_regex .
       \ '\|' .
-      \ crystal#indent#end_end_regex
+      \ g:crystal#indent#end_end_regex
+lockvar g:crystal#indent#crystal_deindent_keywords
 
 " Regex that defines continuation lines, not including (, {, or [.
-const crystal#indent#non_bracket_continuation_regex = '\%([\\.,:*/%+]\|\<and\|\<or\|\%(<%\)\@<![=-]\|\W[|&?]\|||\|&&\)\s*\%(#.*\)\=$'
+let g:crystal#indent#non_bracket_continuation_regex = '\%([\\.,:*/%+]\|\<and\|\<or\|\%(<%\)\@<![=-]\|\W[|&?]\|||\|&&\)\s*\%(#.*\)\=$'
+lockvar g:crystal#indent#non_bracket_continuation_regex
 
 " Regex that defines continuation lines.
-const crystal#indent#continuation_regex =
+let g:crystal#indent#continuation_regex =
       \ '\%(%\@<![({[\\.,:*/%+]\|\<and\|\<or\|\%(<%\)\@<![=-]\|\W[|&?]\|||\|&&\)\s*\%(#.*\)\=$'
+lockvar g:crystal#indent#continuation_regex
 
 " Regex that defines continuable keywords
-const crystal#indent#continuable_regex =
+let g:crystal#indent#continuable_regex =
       \ '\%(^\s*\|[=,*/%+\-|;{]\|<<\|>>\|:\s\)\s*\zs' .
       \ '\<\%(if\|for\|while\|until\|unless\):\@!\>'
+lockvar g:crystal#indent#continuable_regex
 
 " Regex that defines bracket continuations
-const crystal#indent#bracket_continuation_regex = '%\@<!\%([({[]\)\s*\%(#.*\)\=$'
+let g:crystal#indent#bracket_continuation_regex = '%\@<!\%([({[]\)\s*\%(#.*\)\=$'
+lockvar g:crystal#indent#bracket_continuation_regex
 
 " Regex that defines end of bracket continuation followed by another continuation
-const crystal#indent#bracket_switch_continuation_regex = '^\([^(]\+\zs).\+\)\+'.crystal#indent#continuation_regex
+let g:crystal#indent#bracket_switch_continuation_regex = '^\([^(]\+\zs).\+\)\+'.g:crystal#indent#continuation_regex
+lockvar g:crystal#indent#bracket_switch_continuation_regex
 
 " Regex that defines the first part of a splat pattern
-const crystal#indent#splat_regex = '[[,(]\s*\*\s*\%(#.*\)\=$'
+let g:crystal#indent#splat_regex = '[[,(]\s*\*\s*\%(#.*\)\=$'
+lockvar g:crystal#indent#splat_regex
 
 " Regex that defines blocks.
 "
@@ -90,13 +106,16 @@ const crystal#indent#splat_regex = '[[,(]\s*\*\s*\%(#.*\)\=$'
 "
 " The reason is that the pipe matches a hanging "|" operator.
 "
-const crystal#indent#block_regex =
+let g:crystal#indent#block_regex =
       \ '\%(\<do:\@!\>\|%\@<!{\)\s*\%(|\s*(*\s*\%([*@&]\=\h\w*,\=\s*\)\%(,\s*(*\s*[*@&]\=\h\w*\s*)*\s*\)*|\)\=\s*\%(%}\)\=\s*\%(#.*\)\=$'
+lockvar g:crystal#indent#block_regex
 
-const crystal#indent#block_continuation_regex = '^\s*[^])}\t ].*'.crystal#indent#block_regex
+let g:crystal#indent#block_continuation_regex = '^\s*[^])}\t ].*'.g:crystal#indent#block_regex
+lockvar g:crystal#indent#block_continuation_regex
 
 " Regex that describes a leading operator (only a method call's dot for now)
-const crystal#indent#leading_operator_regex = '^\s*[.]'
+let g:crystal#indent#leading_operator_regex = '^\s*[.]'
+lockvar g:crystal#indent#leading_operator_regex
 
 " Auxiliary Functions {{{1
 " ===================

--- a/autoload/ecrystal.vim
+++ b/autoload/ecrystal.vim
@@ -1,0 +1,30 @@
+let s:ecrystal_extensions = {
+      \ 'cr': 'crystal',
+      \ 'yml': 'yaml',
+      \ 'js': 'javascript',
+      \ 'txt': 'text',
+      \ 'md': 'markdown'
+      \ }
+
+if exists('g:ecrystal_extensions')
+  call extend(s:ecrystal_extensions, g:ecrystal_extensions, 'force')
+endif
+
+function ecrystal#SetSubtype()
+  if exists('b:ecrystal_subtype')
+    return
+  endif
+
+  let b:ecrystal_subtype = matchstr(substitute(expand('%:t'), '\c\%(\.ecr\)\+$', '', ''), '\.\zs\w\+\%(\ze+\w\+\)\=$')
+
+  let b:ecrystal_subtype = get(s:ecrystal_extensions, b:ecrystal_subtype, b:ecrystal_subtype)
+
+  if b:ecrystal_subtype == ''
+    let b:ecrystal_subtype = get(g:, 'ecrystal_default_subtype', 'html')
+  endif
+
+  if b:ecrystal_subtype != ''
+    exec 'setlocal filetype=ecrystal.' . b:ecrystal_subtype
+    exec 'setlocal syntax=ecrystal.' . b:ecrystal_subtype
+  endif
+endfunction

--- a/ftdetect/crystal.vim
+++ b/ftdetect/crystal.vim
@@ -1,4 +1,3 @@
 " vint: -ProhibitAutocmdWithNoGroup
 autocmd BufNewFile,BufReadPost *.cr setlocal filetype=crystal
 autocmd BufNewFile,BufReadPost Projectfile setlocal filetype=crystal
-autocmd BufNewFile,BufReadPost *.ecr setlocal filetype=eruby

--- a/ftdetect/ecrystal.vim
+++ b/ftdetect/ecrystal.vim
@@ -1,0 +1,2 @@
+" vint: -ProhibitAutocmdWithNoGroup
+autocmd BufNewFile,BufReadPost *.ecr setlocal filetype=ecrystal

--- a/ftplugin/crystal.vim
+++ b/ftplugin/crystal.vim
@@ -74,6 +74,11 @@ if &l:ofu ==# ''
   setlocal omnifunc=crystal_lang#complete
 endif
 
+if exists('AutoPairsLoaded')
+  let b:AutoPairs = { '{%': '%}' }
+  call extend(b:AutoPairs, g:AutoPairs, 'force')
+endif
+
 let &cpo = s:save_cpo
 unlet s:save_cpo
 

--- a/ftplugin/ecrystal.vim
+++ b/ftplugin/ecrystal.vim
@@ -1,0 +1,96 @@
+if exists('b:did_ftplugin')
+  finish
+endif
+
+" Define some defaults in case the included ftplugins don't set them.
+let s:comments = ''
+let s:shiftwidth = ''
+let s:undo_ftplugin = ''
+let s:browsefilter = 'All Files (*.*)\t*.*\n'
+let s:match_words = ''
+
+call ecrystal#SetSubtype()
+
+if b:ecrystal_subtype != ''
+  exe 'runtime! ftplugin/'.b:ecrystal_subtype.'.vim ftplugin/'.b:ecrystal_subtype.'_*.vim ftplugin/'.b:ecrystal_subtype.'/*.vim'
+  unlet! b:did_ftplugin
+
+  " Keep the comments for this filetype
+  let s:comments = escape(&comments, ' \')
+
+  " Keep the shiftwidth for this filetype
+  let s:shiftwidth = &shiftwidth
+
+  " Override our defaults if these were set by an included ftplugin.
+  if exists('b:undo_ftplugin')
+    let s:undo_ftplugin = b:undo_ftplugin
+    unlet b:undo_ftplugin
+  endif
+  if exists('b:browsefilter')
+    let s:browsefilter = b:browsefilter
+    unlet b:browsefilter
+  endif
+  if exists('b:match_words')
+    let s:match_words = b:match_words
+    unlet b:match_words
+  endif
+endif
+
+runtime! ftplugin/crystal.vim ftplugin/crystal_*.vim ftplugin/crystal/*.vim
+let b:did_ftplugin = 1
+
+" Combine the new set of values with those previously included.
+if exists('b:undo_ftplugin')
+  let s:undo_ftplugin = b:undo_ftplugin . ' | ' . s:undo_ftplugin
+endif
+if exists ('b:browsefilter')
+  let s:browsefilter = substitute(b:browsefilter,'\cAll Files (\*\.\*)\t\*\.\*\n','','') . s:browsefilter
+endif
+if exists('b:match_words')
+  let s:match_words = b:match_words . ',' . s:match_words
+endif
+
+" Change the browse dialog on Win32 to show mainly eCrystal-related files
+if has('gui_win32')
+  let b:browsefilter='eCrystal Files (*.ecr)\t*.ecr\n' . s:browsefilter
+endif
+
+" Load the combined list of match_words for matchit.vim
+if exists('loaded_matchit')
+  let b:match_words = s:match_words
+endif
+
+" Define additional pairs for jiangmiao/auto-pairs
+if exists('AutoPairsLoaded')
+  let b:AutoPairs = {
+        \ '<%': '%>',
+        \ '<%=': '%>',
+        \ '<%#': '%>',
+        \ '<%-': '-%>',
+        \ '<%-=': '-%>',
+        \ '<%-#': '-%>',
+        \ }
+
+  call extend(b:AutoPairs, g:AutoPairs, 'force')
+endif
+
+" Load the subtype's vim-endwise settings
+if exists('loaded_endwise')
+  exec 'doautocmd endwise Filetype ' . b:ecrystal_subtype
+endif
+
+" Start RagTag
+if exists('loaded_ragtag')
+  call RagtagInit()
+endif
+
+exec 'setlocal comments='.s:comments
+exec 'setlocal shiftwidth='.s:shiftwidth
+setlocal commentstring=<%#%s%>
+
+setlocal suffixesadd=.ecr
+
+let b:undo_ftplugin = 'setlocal comments< commentstring< shiftwidth<' .
+      \ '| unlet! b:browsefilter b:match_words ' .
+      \ '| unlet! b:AutoPairs ' .
+      \ '| ' . s:undo_ftplugin

--- a/ftplugin/ecrystal.vim
+++ b/ftplugin/ecrystal.vim
@@ -75,8 +75,8 @@ if exists('AutoPairsLoaded')
 endif
 
 " Load the subtype's vim-endwise settings
-if exists('loaded_endwise')
-  exec 'doautocmd endwise Filetype ' . b:ecrystal_subtype
+if exists('loaded_endwise') && b:ecrystal_subtype != ''
+  exec 'doautocmd endwise FileType ' . b:ecrystal_subtype
 endif
 
 " Start RagTag

--- a/indent/crystal.vim
+++ b/indent/crystal.vim
@@ -4,431 +4,78 @@ if exists('b:did_indent')
 endif
 let b:did_indent = 1
 
-if !exists('g:crystal_indent_access_modifier_style')
-  " Possible values: "normal", "indent", "outdent"
-  let g:crystal_indent_access_modifier_style = 'normal'
-endif
-
 setlocal nosmartindent
 
 " Now, set up our indentation expression and keys that trigger it.
 setlocal indentexpr=GetCrystalIndent(v:lnum)
 setlocal indentkeys=0{,0},0),0],!^F,o,O,e,:,.
-setlocal indentkeys+==end,=else,=elsif,=when,=ensure,=rescue,==begin,==end
+setlocal indentkeys+==end,=else,=elsif,=when,=ensure,=rescue
 setlocal indentkeys+==private,=protected
+
+let s:cpo_save = &cpo
+set cpo&vim
 
 " Only define the function once.
 if exists('*GetCrystalIndent')
   finish
 endif
 
-let s:cpo_save = &cpo
-set cpo&vim
+" Return the value of a single shift-width
+if exists('*shiftwidth')
+  let s:sw = function('shiftwidth')
+else
+  function s:sw()
+    return &shiftwidth
+  endfunction
+endif
 
-" 1. Variables {{{1
-" ============
-
-" Regex of syntax group names that are or delimit strings/symbols or are comments.
-let s:syng_strcom = '\<crystal\%(Regexp\|RegexpDelimiter\|RegexpEscape' .
-      \ '\|Symbol\|String\|StringDelimiter\|StringEscape\|CharLiteral\|ASCIICode' .
-      \ '\|Interpolation\|InterpolationDelimiter\|NoInterpolation\|Comment\|Documentation\)\>'
-
-" Regex of syntax group names that are strings.
-let s:syng_string =
-      \ '\<crystal\%(String\|Interpolation\|NoInterpolation\|StringEscape\)\>'
-
-" Regex of syntax group names that are strings or documentation.
-let s:syng_stringdoc =
-      \'\<crystal\%(String\|Interpolation\|NoInterpolation\|StringEscape\|Documentation\)\>'
-
-" Expression used to check whether we should skip a match with searchpair().
-let s:skip_expr =
-      \ "synIDattr(synID(line('.'),col('.'),1),'name') =~ '".s:syng_strcom."'"
-
-" Regex used for words that, at the start of a line, add a level of indent.
-let s:crystal_indent_keywords =
-      \ '^\s*\zs\<\%(\%(\%(private\|protected\)\s\+\)\=\%(abstract\s\+\)\=\%(class\|struct\)' .
-      \ '\|if\|for\|while\|until\|else\|elsif\|case\|when\|unless\|begin\|ensure\|rescue\|union' .
-      \ '\|\%(private\|protected\)\=\s*\%(def\|class\|struct\|module\|macro\|lib\|enum\)\):\@!\>' .
-      \ '\|\%([=,*/%+-]\|<<\|>>\|:\s\)\s*\zs' .
-      \ '\<\%(if\|for\|while\|until\|case\|unless\|begin\):\@!\>' .
-      \ '\|{%\s*\<\%(if\|for\|while\|until\|case\|unless\|begin\|else\|elsif\|when\)'
-
-" Regex used for words that, at the start of a line, remove a level of indent.
-let s:crystal_deindent_keywords =
-      \ '^\s*\zs\<\%(ensure\|else\|rescue\|elsif\|when\|end\):\@!\>' .
-      \ '\|{%\s*\<\%(ensure\|else\|rescue\|elsif\|when\|end\)\>'
-
-" Regex that defines the start-match for the 'end' keyword.
-" TODO: the do here should be restricted somewhat (only at end of line)?
-let s:end_start_regex =
-      \ '{%\s*\<\%(if\|for\|while\|until\|unless\|begin\)\>\|' .
-      \ '\C\%(^\s*\|[=,*/%+\-|;{]\|<<\|>>\|:\s\)\s*\zs' .
-      \ '\<\%(\%(\%(private\|protected\)\s\+\)\=\%(abstract\s\+\)\=\%(class\|struct\)' .
-      \ '\|if\|for\|while\|until\|case\|unless\|begin\|union' .
-      \ '\|\%(private\|protected\)\=\s*\%(def\|lib\|enum\|macro\|module\)\):\@!\>' .
-      \ '\|\%(^\|[^.:@$]\)\@<=\<do:\@!\>'
-
-" Regex that defines the middle-match for the 'end' keyword.
-let s:end_middle_regex =
-      \ '{%\s*\<\%(ensure\|else\|when\|elsif\)\>\s*%}\|' .
-      \ '\<\%(ensure\|else\|\%(\%(^\|;\)\s*\)\@<=\<rescue:\@!\>\|when\|elsif\):\@!\>'
-
-" Regex that defines the end-match for the 'end' keyword.
-let s:end_end_regex = '\%(^\|[^.:@$]\)\@<=\<end:\@!\>\|{%\s*\<\%(end\)\>'
-
-" Expression used for searchpair() call for finding match for 'end' keyword.
-let s:end_skip_expr = s:skip_expr .
-      \ ' || (expand("<cword>") == "do"' .
-      \ ' && getline(".") =~ "^\\s*\\<\\(while\\|until\\|for\\):\\@!\\>")'
-
-" Regex that defines continuation lines, not including (, {, or [.
-let s:non_bracket_continuation_regex = '\%([\\.,:*/%+]\|\<and\|\<or\|\%(<%\)\@<![=-]\|\W[|&?]\|||\|&&\)\s*\%(#.*\)\=$'
-
-" Regex that defines continuation lines.
-let s:continuation_regex =
-      \ '\%(%\@<![({[\\.,:*/%+]\|\<and\|\<or\|\%(<%\)\@<![=-]\|\W[|&?]\|||\|&&\)\s*\%(#.*\)\=$'
-
-" Regex that defines continuable keywords
-let s:continuable_regex =
-      \ '\C\%(^\s*\|[=,*/%+\-|;{]\|<<\|>>\|:\s\)\s*\zs' .
-      \ '\<\%(if\|for\|while\|until\|unless\):\@!\>'
-
-" Regex that defines bracket continuations
-let s:bracket_continuation_regex = '%\@<!\%([({[]\)\s*\%(#.*\)\=$'
-
-" Regex that defines end of bracket continuation followed by another continuation
-let s:bracket_switch_continuation_regex = '^\([^(]\+\zs).\+\)\+'.s:continuation_regex
-
-" Regex that defines the first part of a splat pattern
-let s:splat_regex = '[[,(]\s*\*\s*\%(#.*\)\=$'
-
-" Regex that defines blocks.
-"
-" Note that there's a slight problem with this regex and s:continuation_regex.
-" Code like this will be matched by both:
-"
-"   method_call do |(a, b)|
-"
-" The reason is that the pipe matches a hanging "|" operator.
-"
-let s:block_regex =
-      \ '\%(\<do:\@!\>\|%\@<!{\)\s*\%(|\s*(*\s*\%([*@&]\=\h\w*,\=\s*\)\%(,\s*(*\s*[*@&]\=\h\w*\s*)*\s*\)*|\)\=\s*\%(#.*\)\=$'
-
-let s:block_continuation_regex = '^\s*[^])}\t ].*'.s:block_regex
-
-" Regex that describes a leading operator (only a method call's dot for now)
-let s:leading_operator_regex = '^\s*[.]'
-
-" Regex that describes all indent access modifiers
-let s:access_modifier_regex = '\C^\s*\%(protected\|private\)\s*\%(#.*\)\=$'
-
-" 2. Auxiliary Functions {{{1
-" ======================
-
-" Check if the character at lnum:col is inside a string, comment, or is ascii.
-function s:IsInStringOrComment(lnum, col)
-  return synIDattr(synID(a:lnum, a:col, 1), 'name') =~# s:syng_strcom
-endfunction
-
-" Check if the character at lnum:col is inside a string.
-function s:IsInString(lnum, col)
-  return synIDattr(synID(a:lnum, a:col, 1), 'name') =~# s:syng_string
-endfunction
-
-" Check if the character at lnum:col is inside a string or documentation.
-function s:IsInStringOrDocumentation(lnum, col)
-  return synIDattr(synID(a:lnum, a:col, 1), 'name') =~# s:syng_stringdoc
-endfunction
-
-" Check if the character at lnum:col is inside a string delimiter
-function s:IsInStringDelimiter(lnum, col)
-  return synIDattr(synID(a:lnum, a:col, 1), 'name') ==# 'crystalStringDelimiter'
-endfunction
-
-" Find line above 'lnum' that isn't empty, in a comment, or in a string.
-function s:PrevNonBlankNonString(lnum)
-  let in_block = 0
-  let lnum = prevnonblank(a:lnum)
-  while lnum > 0
-    " Go in and out of blocks comments as necessary.
-    " If the line isn't empty (with opt. comment) or in a string, end search.
-    let line = getline(lnum)
-    if line =~# '^=begin'
-      if in_block
-        let in_block = 0
-      else
-        break
-      endif
-    elseif !in_block && line =~# '^=end'
-      let in_block = 1
-    elseif !in_block && line !~# '^\s*#.*$' && !(s:IsInStringOrComment(lnum, 1)
-          \ && s:IsInStringOrComment(lnum, strlen(line)))
-      break
-    endif
-    let lnum = prevnonblank(lnum - 1)
-  endwhile
-  return lnum
-endfunction
-
-" Find line above 'lnum' that started the continuation 'lnum' may be part of.
-function s:GetMSL(lnum)
-  " Start on the line we're at and use its indent.
-  let msl = a:lnum
-  let msl_body = getline(msl)
-  let lnum = s:PrevNonBlankNonString(a:lnum - 1)
-  while lnum > 0
-    " If we have a continuation line, or we're in a string, use line as MSL.
-    " Otherwise, terminate search as we have found our MSL already.
-    let line = getline(lnum)
-
-    if s:Match(msl, s:leading_operator_regex)
-      " If the current line starts with a leading operator, keep its indent
-      " and keep looking for an MSL.
-      let msl = lnum
-    elseif s:Match(lnum, s:splat_regex)
-      " If the above line looks like the "*" of a splat, use the current one's
-      " indentation.
-      "
-      " Example:
-      "   Hash[*
-      "     method_call do
-      "       something
-      "
-      return msl
-    elseif s:Match(lnum, s:non_bracket_continuation_regex) &&
-          \ s:Match(msl, s:non_bracket_continuation_regex)
-      " If the current line is a non-bracket continuation and so is the
-      " previous one, keep its indent and continue looking for an MSL.
-      "
-      " Example:
-      "   method_call one,
-      "     two,
-      "     three
-      "
-      let msl = lnum
-    elseif s:Match(lnum, s:non_bracket_continuation_regex) &&
-          \ (s:Match(msl, s:bracket_continuation_regex) || s:Match(msl, s:block_continuation_regex))
-      " If the current line is a bracket continuation or a block-starter, but
-      " the previous is a non-bracket one, respect the previous' indentation,
-      " and stop here.
-      "
-      " Example:
-      "   method_call one,
-      "     two {
-      "     three
-      "
-      return lnum
-    elseif s:Match(lnum, s:bracket_continuation_regex) &&
-          \ (s:Match(msl, s:bracket_continuation_regex) || s:Match(msl, s:block_continuation_regex))
-      " If both lines are bracket continuations (the current may also be a
-      " block-starter), use the current one's and stop here
-      "
-      " Example:
-      "   method_call(
-      "     other_method_call(
-      "       foo
-      return msl
-    elseif s:Match(lnum, s:block_regex) &&
-          \ !s:Match(msl, s:continuation_regex) &&
-          \ !s:Match(msl, s:block_continuation_regex)
-      " If the previous line is a block-starter and the current one is
-      " mostly ordinary, use the current one as the MSL.
-      "
-      " Example:
-      "   method_call do
-      "     something
-      "     something_else
-      return msl
-    else
-      let col = match(line, s:continuation_regex) + 1
-      if (col > 0 && !s:IsInStringOrComment(lnum, col))
-            \ || s:IsInString(lnum, strlen(line))
-        let msl = lnum
-      else
-        break
-      endif
-    endif
-
-    let msl_body = getline(msl)
-    let lnum = s:PrevNonBlankNonString(lnum - 1)
-  endwhile
-  return msl
-endfunction
-
-" Check if line 'lnum' has more opening brackets than closing ones.
-function s:ExtraBrackets(lnum)
-  let opening = {'parentheses': [], 'braces': [], 'brackets': []}
-  let closing = {'parentheses': [], 'braces': [], 'brackets': []}
-
-  let line = getline(a:lnum)
-  let pos  = match(line, '[][(){}]', 0)
-
-  " Save any encountered opening brackets, and remove them once a matching
-  " closing one has been found. If a closing bracket shows up that doesn't
-  " close anything, save it for later.
-  while pos != -1
-    if !s:IsInStringOrComment(a:lnum, pos + 1)
-      if line[pos] ==# '('
-        call add(opening.parentheses, {'type': '(', 'pos': pos})
-      elseif line[pos] ==# ')'
-        if empty(opening.parentheses)
-          call add(closing.parentheses, {'type': ')', 'pos': pos})
-        else
-          let opening.parentheses = opening.parentheses[0:-2]
-        endif
-      elseif line[pos] ==# '{'
-        call add(opening.braces, {'type': '{', 'pos': pos})
-      elseif line[pos] ==# '}'
-        if empty(opening.braces)
-          call add(closing.braces, {'type': '}', 'pos': pos})
-        else
-          let opening.braces = opening.braces[0:-2]
-        endif
-      elseif line[pos] ==# '['
-        call add(opening.brackets, {'type': '[', 'pos': pos})
-      elseif line[pos] ==# ']'
-        if empty(opening.brackets)
-          call add(closing.brackets, {'type': ']', 'pos': pos})
-        else
-          let opening.brackets = opening.brackets[0:-2]
-        endif
-      endif
-    endif
-
-    let pos = match(line, '[][(){}]', pos + 1)
-  endwhile
-
-  " Find the rightmost brackets, since they're the ones that are important in
-  " both opening and closing cases
-  let rightmost_opening = {'type': '(', 'pos': -1}
-  let rightmost_closing = {'type': ')', 'pos': -1}
-
-  for opening in opening.parentheses + opening.braces + opening.brackets
-    if opening.pos > rightmost_opening.pos
-      let rightmost_opening = opening
-    endif
-  endfor
-
-  for closing in closing.parentheses + closing.braces + closing.brackets
-    if closing.pos > rightmost_closing.pos
-      let rightmost_closing = closing
-    endif
-  endfor
-
-  return [rightmost_opening, rightmost_closing]
-endfunction
-
-function s:Match(lnum, regex)
-  let line   = getline(a:lnum)
-  let offset = match(line, '\C'.a:regex)
-  let col    = offset + 1
-
-  while offset > -1 && s:IsInStringOrComment(a:lnum, col)
-    let offset = match(line, '\C'.a:regex, offset + 1)
-    let col = offset + 1
-  endwhile
-
-  if offset > -1
-    return col
-  else
-    return 0
-  endif
-endfunction
-
-" Locates the containing class/module's definition line, ignoring nested classes
-" along the way.
-"
-function! s:FindContainingClass()
-  let saved_position = getpos('.')
-
-  while searchpair(s:end_start_regex, s:end_middle_regex, s:end_end_regex, 'bW',
-        \ s:end_skip_expr) > 0
-    if expand('<cword>') =~# '\<class\|module\>'
-      let found_lnum = line('.')
-      call setpos('.', saved_position)
-      return found_lnum
-    endif
-  endwhile
-
-  call setpos('.', saved_position)
-  return 0
-endfunction
-
-" 3. GetCrystalIndent Function {{{1
+" GetCrystalIndent Function {{{1
 " =========================
 
 function GetCrystalIndent(...)
-  " 3.1. Setup {{{2
-  " ----------
-
-  " The value of a single shift-width
-  if exists('*shiftwidth')
-    let sw = shiftwidth()
-  else
-    let sw = &sw
-  endif
+  " Setup {{{2
+  " -----
 
   " For the current line, use the first argument if given, else v:lnum
   let clnum = a:0 ? a:1 : v:lnum
 
-  " Set up variables for restoring position in file.  Could use clnum here.
-  let vcol = col('.')
+  " Set up variables for restoring position in file
+  let vcol = col(clnum)
 
-  " 3.2. Work on the current line {{{2
-  " -----------------------------
+  " Work on the current line {{{2
+  " ------------------------
 
   " Get the current line.
   let line = getline(clnum)
   let ind = -1
 
-  " If this line is an access modifier keyword, align according to the closest
-  " class declaration.
-  if g:crystal_indent_access_modifier_style ==? 'indent'
-    if s:Match(clnum, s:access_modifier_regex)
-      let class_line = s:FindContainingClass()
-      if class_line > 0
-        return indent(class_line) + sw
-      endif
-    endif
-  elseif g:crystal_indent_access_modifier_style ==? 'outdent'
-    if s:Match(clnum, s:access_modifier_regex)
-      let class_line = s:FindContainingClass()
-      if class_line > 0
-        return indent(class_line)
-      endif
-    endif
-  endif
-
   " If we got a closing bracket on an empty line, find its match and indent
   " according to it.  For parentheses we indent to its column - 1, for the
   " others we indent to the containing line's MSL's level.  Return -1 if fail.
   let col = matchend(line, '^\s*[]})]')
-  if col > 0 && !s:IsInStringOrComment(clnum, col)
+  if col > 0 && !crystal#indent#IsInStringOrComment(clnum, col)
     call cursor(clnum, col)
     let bs = strpart('(){}[]', stridx(')}]', line[col - 1]) * 2, 2)
-    if searchpair(escape(bs[0], '\['), '', bs[1], 'bW', s:skip_expr) > 0
+    if searchpair(escape(bs[0], '\['), '', bs[1], 'bW', g:crystal#indent#skip_expr)
       if line[col-1] ==# ')' && col('.') != col('$') - 1
         let ind = virtcol('.') - 1
       else
-        let ind = indent(s:GetMSL(line('.')))
+        let ind = indent(crystal#indent#GetMSL(line('.')))
       endif
     endif
     return ind
   endif
 
-  " If we have a =begin or =end set indent to first column.
-  if match(line, '^\s*\%(=begin\|=end\)$') != -1
-    return 0
-  endif
-
   " If we have a deindenting keyword, find its match and indent to its level.
   " TODO: this is messy
-  if s:Match(clnum, s:crystal_deindent_keywords)
+  if crystal#indent#Match(clnum, g:crystal#indent#crystal_deindent_keywords)
     call cursor(clnum, 1)
-    if searchpair(s:end_start_regex, s:end_middle_regex, s:end_end_regex, 'bW',
-          \ s:end_skip_expr) > 0
-      let msl  = s:GetMSL(line('.'))
+    if searchpair(
+          \ g:crystal#indent#end_start_regex,
+          \ g:crystal#indent#end_middle_regex,
+          \ g:crystal#indent#end_end_regex,
+          \ 'bW', g:crystal#indent#skip_expr)
+      let msl  = crystal#indent#GetMSL(line('.'))
       let line = getline(line('.'))
 
       if strpart(line, 0, col('.') - 1) =~# '=\s*$' &&
@@ -447,29 +94,29 @@ function GetCrystalIndent(...)
     return ind
   endif
 
-  " If we are in a multi-line string or line-comment, don't do anything to it.
-  if s:IsInStringOrDocumentation(clnum, matchend(line, '^\s*') + 1)
+  " If we are in a multi-line string, don't do anything to it.
+  if crystal#indent#IsInString(clnum, matchend(line, '^\s*') + 1)
     return indent('.')
   endif
 
   " If we are at the closing delimiter of a "<<" heredoc-style string, set the
   " indent to 0.
   if line =~# '^\k\+\s*$'
-        \ && s:IsInStringDelimiter(clnum, 1)
-        \ && search('\V<<'.line, 'nbW') > 0
+        \ && crystal#indent#IsInStringDelimiter(clnum, 1)
+        \ && search('\V<<'.line, 'nbW')
     return 0
   endif
 
   " If the current line starts with a leading operator, add a level of indent.
-  if s:Match(clnum, s:leading_operator_regex)
-    return indent(s:GetMSL(clnum)) + sw
+  if crystal#indent#Match(clnum, g:crystal#indent#leading_operator_regex)
+    return indent(crystal#indent#GetMSL(clnum)) + s:sw()
   endif
 
-  " 3.3. Work on the previous line. {{{2
-  " -------------------------------
+  " Work on the previous line. {{{2
+  " --------------------------
 
   " Find a non-blank, non-multi-line string line above the current line.
-  let lnum = s:PrevNonBlankNonString(clnum - 1)
+  let lnum = crystal#indent#PrevNonBlankNonString(clnum - 1)
 
   " If the line is empty and inside a string, use the previous line.
   if line =~# '^\s*$' && lnum != prevnonblank(clnum - 1)
@@ -485,33 +132,34 @@ function GetCrystalIndent(...)
   let line = getline(lnum)
   let ind = indent(lnum)
 
-  if s:Match(lnum, s:continuable_regex) && s:Match(lnum, s:continuation_regex)
-    return indent(s:GetMSL(lnum)) + sw + sw
+  if crystal#indent#Match(lnum, g:crystal#indent#continuable_regex) &&
+        \ crystal#indent#Match(lnum, g:crystal#indent#continuation_regex)
+    return indent(crystal#indent#GetMSL(lnum)) + s:sw() * 2
   endif
 
   " If the previous line ended with a block opening, add a level of indent.
-  if s:Match(lnum, s:block_regex)
-    let msl = s:GetMSL(lnum)
+  if crystal#indent#Match(lnum, g:crystal#indent#block_regex)
+    let msl = crystal#indent#GetMSL(lnum)
 
     if getline(msl) =~# '=\s*\(#.*\)\=$'
       " in the case of assignment to the msl, align to the starting line,
       " not to the msl
-      let ind = indent(lnum) + sw
+      let ind = indent(lnum) + s:sw()
     else
-      let ind = indent(msl) + sw
+      let ind = indent(msl) + s:sw()
     endif
     return ind
   endif
 
   " If the previous line started with a leading operator, use its MSL's level
   " of indent
-  if s:Match(lnum, s:leading_operator_regex)
-    return indent(s:GetMSL(lnum))
+  if crystal#indent#Match(lnum, g:crystal#indent#leading_operator_regex)
+    return indent(crystal#indent#GetMSL(lnum))
   endif
 
   " If the previous line ended with the "*" of a splat, add a level of indent
-  if line =~ s:splat_regex
-    return indent(lnum) + sw
+  if line =~ g:crystal#indent#splat_regex
+    return indent(lnum) + s:sw()
   endif
 
   " If the previous line contained unclosed opening brackets and we are still
@@ -521,25 +169,25 @@ function GetCrystalIndent(...)
   " If it contained hanging closing brackets, find the rightmost one, find its
   " match and indent according to that.
   if line =~# '[[({]' || line =~# '[])}]\s*\%(#.*\)\=$'
-    let [opening, closing] = s:ExtraBrackets(lnum)
+    let [opening, closing] = crystal#indent#ExtraBrackets(lnum)
 
     if opening.pos != -1
-      if opening.type ==# '(' && searchpair('(', '', ')', 'bW', s:skip_expr) > 0
+      if opening.type ==# '(' && searchpair('(', '', ')', 'bW', g:crystal#indent#skip_expr)
         if col('.') + 1 == col('$')
-          return ind + sw
+          return ind + s:sw()
         else
           return virtcol('.')
         endif
       else
         let nonspace = matchend(line, '\S', opening.pos + 1) - 1
-        return nonspace > 0 ? nonspace : ind + sw
+        return nonspace > 0 ? nonspace : ind + s:sw()
       endif
     elseif closing.pos != -1
       call cursor(lnum, closing.pos + 1)
       normal! %
 
-      if s:Match(line('.'), s:crystal_indent_keywords)
-        return indent('.') + sw
+      if crystal#indent#Match(line('.'), g:crystal#indent#crystal_indent_keywords)
+        return indent('.') + s:sw()
       else
         return indent('.')
       endif
@@ -550,14 +198,14 @@ function GetCrystalIndent(...)
 
   " If the previous line ended with an "end", match that "end"s beginning's
   " indent.
-  let col = s:Match(lnum, '\%(^\|[^.:@$]\)\<end\>\s*\%(#.*\)\=$')
-  if col > 0
+  let col = crystal#indent#Match(lnum, '\%(^\|[^.:@$]\)\<end\>\s*\%(#.*\)\=$')
+  if col
     call cursor(lnum, col)
-    if searchpair(s:end_start_regex, '', s:end_end_regex, 'bW',
-          \ s:end_skip_expr) > 0
+    if searchpair(g:crystal#indent#end_start_regex, '', g:crystal#indent#end_end_regex, 'bW',
+          \ g:crystal#indent#skip_expr)
       let n = line('.')
       let ind = indent('.')
-      let msl = s:GetMSL(n)
+      let msl = crystal#indent#GetMSL(n)
       if msl != n
         let ind = indent(msl)
       end
@@ -565,34 +213,35 @@ function GetCrystalIndent(...)
     endif
   end
 
-  let col = s:Match(lnum, s:crystal_indent_keywords)
-  if col > 0
+  let col = crystal#indent#Match(lnum, g:crystal#indent#crystal_indent_keywords)
+  if col
     call cursor(lnum, col)
-    let ind = virtcol('.') - 1 + sw
+    let ind = virtcol('.') - 1 + s:sw()
     " TODO: make this better (we need to count them) (or, if a searchpair
     " fails, we know that something is lacking an end and thus we indent a
     " level
-    if s:Match(lnum, s:end_end_regex)
+    if crystal#indent#Match(lnum, g:crystal#indent#end_end_regex)
       let ind = indent('.')
     endif
     return ind
   endif
 
-  " 3.4. Work on the MSL line. {{{2
-  " --------------------------
+  " Work on the MSL line. {{{2
+  " ---------------------
 
   " Set up variables to use and search for MSL to the previous line.
   let p_lnum = lnum
-  let lnum = s:GetMSL(lnum)
+  let lnum = crystal#indent#GetMSL(lnum)
 
   " If the previous line wasn't a MSL.
   if p_lnum != lnum
     " If previous line ends bracket and begins non-bracket continuation decrease indent by 1.
-    if s:Match(p_lnum, s:bracket_switch_continuation_regex)
+    if crystal#indent#Match(p_lnum, g:crystal#indent#bracket_switch_continuation_regex)
       return ind - 1
     " If previous line is a continuation return its indent.
-    " TODO: the || s:IsInString() thing worries me a bit.
-    elseif s:Match(p_lnum, s:non_bracket_continuation_regex) || s:IsInString(p_lnum,strlen(line))
+    " TODO: the || crystal#indent#IsInString() thing worries me a bit.
+    elseif crystal#indent#Match(p_lnum, g:crystal#indent#non_bracket_continuation_regex) ||
+          \ crystal#indent#IsInString(p_lnum,strlen(line))
       return ind
     endif
   endif
@@ -604,19 +253,20 @@ function GetCrystalIndent(...)
   " If the MSL line had an indenting keyword in it, add a level of indent.
   " TODO: this does not take into account contrived things such as
   " module Foo; class Bar; end
-  if s:Match(lnum, s:crystal_indent_keywords)
-    let ind = msl_ind + sw
-    if s:Match(lnum, s:end_end_regex)
-      let ind = ind - sw
+  if crystal#indent#Match(lnum, g:crystal#indent#crystal_indent_keywords)
+    let ind = msl_ind + s:sw()
+    if crystal#indent#Match(lnum, g:crystal#indent#end_end_regex)
+      let ind = ind - s:sw()
     endif
     return ind
   endif
 
   " If the previous line ended with [*+/.,-=], but wasn't a block ending or a
   " closing bracket, indent one extra level.
-  if s:Match(lnum, s:non_bracket_continuation_regex) && !s:Match(lnum, '^\s*\([\])}]\|end\)')
+  if crystal#indent#Match(lnum, g:crystal#indent#non_bracket_continuation_regex) &&
+        \ !crystal#indent#Match(lnum, '^\s*\([\])}]\|end\)')
     if lnum == p_lnum
-      let ind = msl_ind + sw
+      let ind = msl_ind + s:sw()
     else
       let ind = msl_ind
     endif

--- a/indent/ecrystal.vim
+++ b/indent/ecrystal.vim
@@ -62,17 +62,17 @@ endif
 " Helper variables and functions {{{1
 " ==============================
 
-const s:ecr_open = '<%%\@!'
-const s:ecr_close = '%>'
+let s:ecr_open = '<%%\@!'
+let s:ecr_close = '%>'
 
-const s:ecr_control_open = '<%%\@!-\=[=#]\@!'
-const s:ecr_comment_open = '<%%\@!-\=#'
+let s:ecr_control_open = '<%%\@!-\=[=#]\@!'
+let s:ecr_comment_open = '<%%\@!-\=#'
 
-const s:ecr_indent_regex =
+let s:ecr_indent_regex =
       \ '\<\%(if\|unless\|else\|elsif\|case\|for\|when\|while\|until\|begin\|do\|rescue\|ensure\|' .
       \ 'class\|module\|struct\|lib\|enum\|union\)\>'
 
-const s:ecr_dedent_regex =
+let s:ecr_dedent_regex =
       \ '\<\%(end\|else\|elsif\|when\|rescue\|ensure\)\>'
 
 " Return the value of a single shift-width

--- a/indent/ecrystal.vim
+++ b/indent/ecrystal.vim
@@ -1,0 +1,487 @@
+" Setup {{{1
+" =====
+
+if exists('b:did_indent')
+  finish
+endif
+
+call ecrystal#SetSubtype()
+
+if b:ecrystal_subtype != ''
+  exec 'runtime! indent/'.b:ecrystal_subtype.'.vim'
+  unlet! b:did_indent
+endif
+
+if &l:indentexpr == ''
+  if &l:cindent
+    let &l:indentexpr = 'cindent(v:lnum)'
+  else
+    let &l:indentexpr = 'indent(prevnonblank(v:lnum - 1))'
+  endif
+endif
+
+let b:ecrystal_subtype_indentexpr = &l:indentexpr
+
+" Should we use folding?
+if has('folding') && get(g:, 'ecrystal_fold', 0)
+  setlocal foldmethod=expr
+  setlocal foldexpr=GetEcrystalFold()
+endif
+
+" Should closing control tags be aligned with their corresponding
+" opening tags?
+if !exists('b:ecrystal_align_end')
+  if exists('g:ecrystal_align_end')
+    let b:ecrystal_align_end = g:ecrystal_align_end
+  else
+    let b:ecrystal_align_end = b:ecrystal_subtype !=# 'html' && b:ecrystal_subtype !=# 'xml'
+  endif
+endif
+
+" Should multiline tags be indented?
+if !exists('b:ecrystal_indent_multiline')
+  let b:ecrystal_indent_multiline = get(g:, 'ecrystal_indent_multiline', 1)
+endif
+
+if b:ecrystal_indent_multiline
+  runtime! indent/crystal.vim
+  unlet! b:did_indent
+  setlocal indentexpr<
+endif
+
+setlocal indentexpr=GetEcrystalIndent()
+setlocal indentkeys+=<>>,=end,=else,=elsif,=rescue,=ensure,=when
+
+let b:did_indent = 1
+
+" Only define the function once.
+if exists('*GetEcrystalIndent')
+  finish
+endif
+
+" Helper variables and functions {{{1
+" ==============================
+
+const s:ecr_open = '<%%\@!'
+const s:ecr_close = '%>'
+
+const s:ecr_control_open = '<%%\@!-\=[=#]\@!'
+const s:ecr_comment_open = '<%%\@!-\=#'
+
+const s:ecr_indent_regex =
+      \ '\<\%(if\|unless\|else\|elsif\|case\|for\|when\|while\|until\|begin\|do\|rescue\|ensure\|' .
+      \ 'class\|module\|struct\|lib\|enum\|union\)\>'
+
+const s:ecr_dedent_regex =
+      \ '\<\%(end\|else\|elsif\|when\|rescue\|ensure\)\>'
+
+" Return the value of a single shift-width
+if exists('*shiftwidth')
+  let s:sw = function('shiftwidth')
+else
+  function s:sw()
+    return &shiftwidth
+  endfunction
+endif
+
+" Return the current cursor position
+function s:Cursor()
+  return [line('.'), col('.')]
+endfunction
+
+" Does the given pattern match at the cursor's position?
+function s:MatchCursor(pattern)
+  return searchpos(a:pattern, 'cnz', line('.')) == s:Cursor()
+endfunction
+
+" Does the given pattern match at the given position?
+function s:MatchAt(lnum, col, pattern)
+  let pos = s:Cursor()
+
+  call cursor(a:lnum, a:col)
+  let result = s:MatchCursor(a:pattern)
+  call cursor(pos)
+
+  return result
+endfunction
+
+" Is the cell at the given position part of a tag? If so, return the
+" position of the opening delimiter.
+function s:MatchECR(...)
+  let pos = s:Cursor()
+
+  if a:0
+    let lnum = a:1
+    let col = a:2
+
+    call cursor(lnum, col)
+  else
+    let [lnum, col] = pos
+  endif
+
+  let flags = s:MatchCursor(s:ecr_open) ? 'bcWz' : 'bWz'
+
+  let [open_lnum, open_col] = searchpairpos(
+        \ s:ecr_open, '', s:ecr_close,
+        \ flags, g:crystal#indent#skip_expr)
+
+  call cursor(pos)
+
+  return [open_lnum, open_col]
+endfunction
+
+" If the cell at the given position is part of a control tag, return the
+" respective positions of the opening and closing delimiters for that
+" tag.
+function s:MatchECRControl(...)
+  let pos = s:Cursor()
+
+  if a:0
+    let lnum = a:1
+    let col = a:2
+
+    call cursor(lnum, col)
+  else
+    let [lnum, col] = pos
+  endif
+
+  let open = { 'lnum': 0, 'col': 0 }
+  let close = { 'lnum': 0, 'col': 0 }
+
+  let [open.lnum, open.col] = s:MatchECR(lnum, col)
+
+  if !open.lnum
+    call cursor(pos)
+    return [open, close]
+  endif
+
+  call cursor(open.lnum, open.col)
+
+  if !s:MatchCursor(s:ecr_control_open)
+    let open.lnum = 0
+    let open.col = 0
+
+    call cursor(pos)
+    return [open, close]
+  endif
+
+  let [close.lnum, close.col] = searchpairpos(
+        \ s:ecr_control_open, '', s:ecr_close,
+        \ 'Wz', g:crystal#indent#skip_expr)
+
+  call cursor(pos)
+  return [open, close]
+endfunction
+
+" Determine whether or not the control tag at the given position starts
+" an indent.
+function s:ECRIndent(...)
+  if a:0
+    if type(a:1) == 0
+      let [open, close] = s:MatchECRControl(a:1, a:2)
+    elseif type(a:1) == 4
+      let [open, close] = [a:1, a:2]
+    endif
+  else
+    let [open, close] = s:MatchECRControl()
+  endif
+
+  let result = 0
+
+  if !open.lnum
+    return result
+  endif
+
+  let pos = s:Cursor()
+
+  call cursor(open.lnum, open.col)
+
+  " Find each Crystal keyword that starts an indent; if any of them do
+  " not have a corresponding ending keyword, then this tag starts an
+  " indent.
+  while search(s:ecr_indent_regex, 'z', close.lnum)
+    let [lnum, col] = s:Cursor()
+
+    if lnum == close.lnum && col > close.col
+      break
+    endif
+
+    if crystal#indent#IsInStringOrComment(lnum, col)
+      continue
+    endif
+
+    let [end_lnum, end_col] = searchpairpos(
+          \ g:crystal#indent#end_start_regex,
+          \ g:crystal#indent#end_middle_regex,
+          \ g:crystal#indent#end_end_regex,
+          \ 'nz',
+          \ g:crystal#indent#skip_expr,
+          \ close.lnum)
+
+    if end_lnum
+      if end_lnum == close.lnum && end_col > close.col
+        let result = 1
+      endif
+    else
+      let result = 1
+    endif
+
+    if result
+      break
+    endif
+  endwhile
+
+  call cursor(pos)
+  return result
+endfunction
+
+" Determine if the control tag at the given position ends an indent or
+" not.
+function s:ECRDedent(...)
+  if a:0
+    if type(a:1) == 0
+      let [open, close] = s:MatchECRControl(a:1, a:2)
+    elseif type(a:1) == 4
+      let [open, close] = [a:1, a:2]
+    endif
+  else
+    let [open, close] = s:MatchECRControl()
+  endif
+
+  let result = 0
+
+  if !open.lnum
+    return result
+  endif
+
+  let pos = s:Cursor()
+
+  call cursor(open.lnum, open.col)
+
+  " Find each Crystal keyword that ends an indent; if any of them do not
+  " have a corresponding starting keyword, then this tag ends an indent
+  while search(s:ecr_dedent_regex, 'z', close.lnum)
+    let [lnum, col] = s:Cursor()
+
+    if lnum == close.lnum && col > close.col
+      break
+    endif
+
+    if crystal#indent#IsInStringOrComment(lnum, col)
+      continue
+    endif
+
+    let [begin_lnum, begin_col] = searchpairpos(
+          \ g:crystal#indent#end_start_regex,
+          \ g:crystal#indent#end_middle_regex,
+          \ g:crystal#indent#end_end_regex,
+          \ 'bnz',
+          \ g:crystal#indent#skip_expr,
+          \ open.lnum)
+
+    if begin_lnum
+      if begin_lnum == open.lnum && begin_col < open.col
+        let result = 1
+      endif
+    else
+      let result = 1
+    endif
+
+    if result
+      break
+    endif
+  endwhile
+
+  call cursor(pos)
+  return result
+endfunction
+
+" Find and match a control tag in the given line, if one exists.
+function s:FindECRControl(...)
+  let lnum = a:0 ? a:1 : line('.')
+
+  let open = { 'lnum': 0, 'col': 0 }
+  let close = { 'lnum': 0, 'col': 0 }
+
+  let pos = s:Cursor()
+
+  call cursor(lnum, 1)
+
+  while search(s:ecr_control_open, 'cz', lnum)
+    let [open, close] = s:MatchECRControl()
+
+    if open.lnum
+      break
+    endif
+  endwhile
+
+  call cursor(pos)
+  return [open, close]
+endfunction
+
+" Find and match the previous control tag.
+"
+" This takes two arguments: the first is the line to start searching
+" from (exclusive); the second is the line to stop searching at
+" (inclusive).
+function s:FindPrevECRControl(...)
+  if a:0 == 0
+    let start = line('.')
+    let stop = 1
+  elseif a:0 == 1
+    let start = a:1
+    let stop = 1
+  elseif a:0 == 2
+    let start = a:1
+    let stop = a:2
+  endif
+
+  let open = { 'lnum': 0, 'col': 0 }
+  let close = { 'lnum': 0, 'col': 0 }
+
+  let pos = s:Cursor()
+
+  call cursor(start, 1)
+
+  let [lnum, col] = searchpos(s:ecr_close, 'bWz', stop)
+
+  if !lnum
+    call cursor(pos)
+    return [open, close]
+  endif
+
+  let [open, close] = s:MatchECRControl()
+
+  while !open.lnum
+    let [lnum, col] = searchpos(s:ecr_close, 'bWz', stop)
+
+    if !lnum
+      break
+    endif
+
+    let [open, close] = s:MatchECRControl()
+  endwhile
+
+  call cursor(pos)
+  return [open, close]
+endfunction
+
+" GetEcrystalIndent {{{1
+" =================
+
+function GetEcrystalIndent() abort
+  let prev_lnum = prevnonblank(v:lnum - 1)
+
+  if b:ecrystal_indent_multiline
+    let [open_tag_lnum, open_tag_col] = s:MatchECR()
+  else
+    let open_tag_lnum = 0
+  endif
+
+  if open_tag_lnum && open_tag_lnum < v:lnum
+    " If we are inside a multiline eCrystal tag...
+
+    let ind = indent(open_tag_lnum)
+
+    " If this line has a closing delimiter that isn't inside a string or
+    " comment, then we are done with this tag
+    if crystal#indent#Match(v:lnum, s:ecr_close)
+      return ind
+    endif
+
+    " All tag contents will have at least one indent
+    let ind += s:sw()
+
+    if open_tag_lnum == prev_lnum
+      " If this is the first line after the opening delimiter, then one
+      " indent is enough
+      return ind
+    elseif s:MatchAt(open_tag_lnum, open_tag_col, s:ecr_comment_open)
+      " eCrystal comments shouldn't be indented any further
+      return ind
+    else
+      " Else, fall back to Crystal indentation...
+      let crystal_ind = GetCrystalIndent()
+
+      " But only if it isn't less than the default indentation for this
+      " tag
+      return crystal_ind < ind ? ind : crystal_ind
+    endif
+  else
+    let [prev_ecr_open, prev_ecr_close] = s:FindPrevECRControl(v:lnum, prev_lnum)
+    let [curr_ecr_open, curr_ecr_close] = s:FindECRControl()
+
+    let prev_is_ecr = prev_ecr_open.lnum != 0
+    let curr_is_ecr = curr_ecr_open.lnum != 0
+
+    let shift = 0
+
+    if prev_is_ecr
+      if s:ECRIndent(prev_ecr_open, prev_ecr_close)
+        let shift = 1
+      endif
+    endif
+
+    if curr_is_ecr
+      if s:ECRDedent(curr_ecr_open, curr_ecr_close)
+        if !b:ecrystal_align_end
+          let shift = shift ? 0 : -1
+        else
+          " Find the nearest previous control tag that starts an indent
+          " and align this one with that one
+          let end_tags = 0
+
+          let [open, close] = s:FindPrevECRControl()
+
+          while open.lnum
+            if s:ECRIndent(open, close)
+              if end_tags
+                let end_tags -= 1
+              else
+                return indent(open.lnum)
+              endif
+            elseif s:ECRDedent(open, close)
+              let end_tags += 1
+            endif
+
+            let [open, close] = s:FindPrevECRControl(open.lnum)
+          endwhile
+        endif
+      endif
+    endif
+
+    if shift
+      return indent(prev_lnum) + s:sw() * shift
+    else
+      exec 'return ' . b:ecrystal_subtype_indentexpr
+    endif
+  endif
+endfunction
+
+" GetEcrystalFold {{{1
+" ===============
+
+function GetEcrystalFold() abort
+  let fold = '='
+
+  let col = crystal#indent#Match(v:lnum, s:ecr_control_open)
+
+  if col
+    let [open, close] = s:MatchECRControl(v:lnum, col)
+
+    let starts_indent = s:ECRIndent(open, close)
+    let ends_indent = s:ECRDedent(open, close)
+
+    if starts_indent && !ends_indent
+      let fold = 'a1'
+    elseif ends_indent && !starts_indent
+      let fold = 's1'
+    endif
+  endif
+
+  return fold
+endfunction
+
+" }}}
+
+" vim:fdm=marker

--- a/syntax/crystal.vim
+++ b/syntax/crystal.vim
@@ -293,7 +293,6 @@ if !exists('b:crystal_no_expensive') && !exists('g:crystal_no_expensive')
 
   " modifiers
   syn match crystalConditionalModifier "\<\%(if\|unless\|ifdef\)\>" display
-  syn match crystalRepeatModifier      "\<\%(while\|until\)\>" display
 
   SynFold 'do' syn region crystalDoBlock matchgroup=crystalControl start="\<do\>" end="\<end\>" contains=TOP
 
@@ -421,7 +420,6 @@ hi def link crystalConditional         Conditional
 hi def link crystalConditionalModifier crystalConditional
 hi def link crystalExceptional         crystalConditional
 hi def link crystalRepeat              Repeat
-hi def link crystalRepeatModifier      crystalRepeat
 hi def link crystalControl             Statement
 hi def link crystalInclude             Include
 hi def link crystalRecord              Statement

--- a/syntax/crystal.vim
+++ b/syntax/crystal.vim
@@ -79,14 +79,14 @@ endif
 if exists('g:crystal_operators')
   syn match  crystalOperator "[~!^&|*/%+-]\|\%(class\s*\)\@<!<<\|<=>\|<=\|\%(<\|\<class\s\+\u\w*\s*\)\@<!<[^<]\@=\|===\|==\|=\~\|>>\|>=\|=\@<!>\|\*\*\|\.\.\.\|\.\.\|::"
   syn match  crystalOperator "->\|-=\|/=\|\*\*=\|\*=\|&&=\|&=\|&&\|||=\||=\|||\|%=\|+=\|!\~\|!=\|//"
-  syn region crystalBracketOperator matchgroup=crystalOperator start="\%(\w[?!]\=\|[]})]\)\@<=\[\s*" end="\s*]" contains=@crystalTop
+  syn region crystalBracketOperator matchgroup=crystalOperator start="\%(\w[?!]\=\|[]})]\)\@<=\[\s*" end="\s*]" contains=TOP
 endif
 
 " Expression Substitution and Backslash Notation
 syn match crystalStringEscape "\\\\\|\\[abefnrstv]\|\\\o\{1,3}\|\\x\x\{1,2}"                            contained display
 syn match crystalStringEscape "\%(\\M-\\C-\|\\C-\\M-\|\\M-\\c\|\\c\\M-\|\\c\|\\C-\|\\M-\)\%(\\\o\{1,3}\|\\x\x\{1,2}\|\\\=\S\)" contained display
 
-syn region crystalInterpolation      matchgroup=crystalInterpolationDelim start="#{" end="}" contained contains=@crystalTop
+syn region crystalInterpolation      matchgroup=crystalInterpolationDelim start="#{" end="}" contained contains=TOP
 syn match  crystalInterpolation      "#\%(\$\|@@\=\)\w\+" display contained contains=crystalInterpolationDelim,crystalInstanceVariable,crystalClassVariable,crystalGlobalVariable,crystalPredefinedVariable
 syn match  crystalInterpolationDelim "#\ze\%(\$\|@@\=\)\w\+" display contained
 syn match  crystalInterpolation      "#\$\%(-\w\|\W\)" display contained contains=crystalInterpolationDelim,crystalPredefinedVariable,crystalInvalidVariable
@@ -227,10 +227,10 @@ SynFold '%' syn region crystalString matchgroup=crystalStringDelimiter start="%[
 SynFold '%' syn region crystalString matchgroup=crystalStringDelimiter start="%[Qx]\=|"  end="|"  skip="\\\\\|\\|"  contains=@crystalStringSpecial,crystalDelimEscape
 
 " Here Document
-syn region crystalHeredocStart matchgroup=crystalStringDelimiter start=+\%(\%(class\s*\|\%([]})"'.]\|::\)\)\_s*\|\w\)\@<!<<-\=\zs\%(\%(\h\|[^\x00-\x7F]\)\%(\w\|[^\x00-\x7F]\)*\)+ end=+$+ oneline contains=@crystalTop
-syn region crystalHeredocStart matchgroup=crystalStringDelimiter start=+\%(\%(class\s*\|\%([]})"'.]\|::\)\)\_s*\|\w\)\@<!<<-\=\zs"\%([^"]*\)"+ end=+$+ oneline contains=@crystalTop
-syn region crystalHeredocStart matchgroup=crystalStringDelimiter start=+\%(\%(class\s*\|\%([]})"'.]\|::\)\)\_s*\|\w\)\@<!<<-\=\zs'\%([^']*\)'+ end=+$+ oneline contains=@crystalTop
-syn region crystalHeredocStart matchgroup=crystalStringDelimiter start=+\%(\%(class\s*\|\%([]})"'.]\|::\)\)\_s*\|\w\)\@<!<<-\=\zs`\%([^`]*\)`+ end=+$+ oneline contains=@crystalTop
+syn region crystalHeredocStart matchgroup=crystalStringDelimiter start=+\%(\%(class\s*\|\%([]})"'.]\|::\)\)\_s*\|\w\)\@<!<<-\=\zs\%(\%(\h\|[^\x00-\x7F]\)\%(\w\|[^\x00-\x7F]\)*\)+ end=+$+ oneline contains=TOP
+syn region crystalHeredocStart matchgroup=crystalStringDelimiter start=+\%(\%(class\s*\|\%([]})"'.]\|::\)\)\_s*\|\w\)\@<!<<-\=\zs"\%([^"]*\)"+ end=+$+ oneline contains=TOP
+syn region crystalHeredocStart matchgroup=crystalStringDelimiter start=+\%(\%(class\s*\|\%([]})"'.]\|::\)\)\_s*\|\w\)\@<!<<-\=\zs'\%([^']*\)'+ end=+$+ oneline contains=TOP
+syn region crystalHeredocStart matchgroup=crystalStringDelimiter start=+\%(\%(class\s*\|\%([]})"'.]\|::\)\)\_s*\|\w\)\@<!<<-\=\zs`\%([^`]*\)`+ end=+$+ oneline contains=TOP
 
 SynFold '<<' syn region crystalString start=+\%(\%(class\|::\)\_s*\|\%([]})"'.]\)\s\|\w\)\@<!<<\z(\%(\h\|[^\x00-\x7F]\)\%(\w\|[^\x00-\x7F]\)*\)\ze\%(.*<<-\=['`"]\=\h\)\@!+hs=s+2 matchgroup=crystalStringDelimiter end=+^\z1$+ contains=crystalHeredocStart,crystalHeredoc,@crystalStringSpecial keepend
 SynFold '<<' syn region crystalString start=+\%(\%(class\|::\)\_s*\|\%([]})"'.]\)\s\|\w\)\@<!<<"\z([^"]*\)"\ze\%(.*<<-\=['`"]\=\h\)\@!+hs=s+2 matchgroup=crystalStringDelimiter end=+^\z1$+ contains=crystalHeredocStart,crystalHeredoc,@crystalStringSpecial keepend
@@ -284,28 +284,29 @@ if !exists('b:crystal_no_expensive') && !exists('g:crystal_no_expensive')
   syn match crystalMacro  "\<macro\>"  nextgroup=crystalMacroDeclaration skipwhite skipnl
   syn match crystalEnum   "\<enum\>"   nextgroup=crystalEnumDeclaration skipwhite skipnl
 
-  SynFold 'def'    syn region crystalMethodBlock start="\<\%(def\|macro\)\>" matchgroup=crystalDefine end="\%(\<\%(def\|macro\)\_s\+\)\@<!\<end\>"  contains=@crystalTop
-  SynFold 'class'  syn region crystalBlock       start="\<class\>"           matchgroup=crystalClass  end="\<end\>"                                 contains=@crystalTop
-  SynFold 'module' syn region crystalBlock       start="\<module\>"          matchgroup=crystalModule end="\<end\>"                                 contains=@crystalTop
-  SynFold 'struct' syn region crystalBlock       start="\<struct\>"          matchgroup=crystalStruct end="\<end\>"                                 contains=@crystalTop
-  SynFold 'lib'    syn region crystalBlock       start="\<lib\>"             matchgroup=crystalLib    end="\<end\>"                                 contains=@crystalTop
-  SynFold 'enum'   syn region crystalBlock       start="\<enum\>"            matchgroup=crystalEnum   end="\<end\>"                                 contains=@crystalTop
+  SynFold 'def'    syn region crystalMethodBlock start="\<\%(def\|macro\)\>" matchgroup=crystalDefine end="\%(\<\%(def\|macro\)\_s\+\)\@<!\<end\>"  contains=TOP
+  SynFold 'class'  syn region crystalBlock       start="\<class\>"           matchgroup=crystalClass  end="\<end\>"                                 contains=TOP
+  SynFold 'module' syn region crystalBlock       start="\<module\>"          matchgroup=crystalModule end="\<end\>"                                 contains=TOP
+  SynFold 'struct' syn region crystalBlock       start="\<struct\>"          matchgroup=crystalStruct end="\<end\>"                                 contains=TOP
+  SynFold 'lib'    syn region crystalBlock       start="\<lib\>"             matchgroup=crystalLib    end="\<end\>"                                 contains=TOP
+  SynFold 'enum'   syn region crystalBlock       start="\<enum\>"            matchgroup=crystalEnum   end="\<end\>"                                 contains=TOP
 
   " modifiers
   syn match crystalConditionalModifier "\<\%(if\|unless\|ifdef\)\>" display
   syn match crystalRepeatModifier      "\<\%(while\|until\)\>" display
 
-  SynFold 'do' syn region crystalDoBlock matchgroup=crystalControl start="\<do\>" end="\<end\>" contains=@crystalTop
+  SynFold 'do' syn region crystalDoBlock matchgroup=crystalControl start="\<do\>" end="\<end\>" contains=TOP
 
   " curly bracket block or hash literal
-  SynFold '{' syn region crystalCurlyBlock   matchgroup=crystalCurlyBlockDelimiter start="{"                     end="}" contains=@crystalTop
-  SynFold '[' syn region crystalArrayLiteral matchgroup=crystalArrayDelimiter      start="\%(\w\|[\]})]\)\@<!\[" end="]" contains=@crystalTop
+  SynFold '{' syn region crystalCurlyBlock   matchgroup=crystalCurlyBlockDelimiter start="{"                     end="}" contains=TOP
+  SynFold '[' syn region crystalArrayLiteral matchgroup=crystalArrayDelimiter      start="\%(\w\|[\]})]\)\@<!\[" end="]" contains=TOP
 
   " statements without 'do'
-  SynFold 'begin'  syn region crystalBlockExpression       matchgroup=crystalControl     start="\<begin\>"  end="\<end\>" contains=@crystalTop
-  SynFold 'case'   syn region crystalCaseExpression        matchgroup=crystalConditional start="\<case\>"   end="\<end\>" contains=@crystalTop
-  SynFold 'select' syn region crystalSelectExpression      matchgroup=crystalConditional start="\<select\>" end="\<end\>" contains=@crystalTop
-  SynFold 'if'     syn region crystalConditionalExpression matchgroup=crystalConditional start="\%(\%(^\|\.\.\.\=\|[{:,;([<>~\*/%&^|+=-]\|\%(\<[_[:lower:]][_[:alnum:]]*\)\@<![?!]\)\s*\)\@<=\%(if\|ifdef\|unless\)\>" end="\%(\%(\%(\.\@<!\.\)\|::\)\s*\)\@<!\<end\>" contains=@crystalTop
+  SynFold 'begin'  syn region crystalBlockExpression       matchgroup=crystalControl     start="\<begin\>"             end="\<end\>" contains=TOP
+  SynFold 'while'  syn region crystalRepeatExpression      matchgroup=crystalRepeat      start="\<\%(while\|until\)\>" end="\<end\>" contains=TOP
+  SynFold 'case'   syn region crystalCaseExpression        matchgroup=crystalConditional start="\<case\>"              end="\<end\>" contains=TOP
+  SynFold 'select' syn region crystalSelectExpression      matchgroup=crystalConditional start="\<select\>"            end="\<end\>" contains=TOP
+  SynFold 'if'     syn region crystalConditionalExpression matchgroup=crystalConditional start="\%(\%(^\|\.\.\.\=\|[{:,;([<>~\*/%&^|+=-]\|\%(\<[_[:lower:]][_[:alnum:]]*\)\@<![?!]\)\s*\)\@<=\%(if\|ifdef\|unless\)\>" end="\%(\%(\%(\.\@<!\.\)\|::\)\s*\)\@<!\<end\>" contains=TOP
 
   syn match crystalConditional "\<\%(then\|else\|when\)\>[?!]\@!" contained containedin=crystalCaseExpression
   syn match crystalConditional "\<\%(when\|else\)\>[?!]\@!" contained containedin=crystalSelectExpression
@@ -314,7 +315,7 @@ if !exists('b:crystal_no_expensive') && !exists('g:crystal_no_expensive')
   syn match crystalExceptional       "\<\%(\%(\%(;\|^\)\s*\)\@<=rescue\|else\|ensure\)\>[?!]\@!" contained containedin=crystalBlockExpression
   syn match crystalMethodExceptional "\<\%(\%(\%(;\|^\)\s*\)\@<=rescue\|else\|ensure\)\>[?!]\@!" contained containedin=crystalMethodBlock
 
-  SynFold 'macro' syn region crystalMacroBlock matchgroup=crystalMacroRegion start="\z(\\\=\){%\s*\%(\%(if\|for\|begin\)\>.*\|.*\<do\>\)\s*%}" end="\z1{%\s*end\s*%}" transparent contains=@crystalTop
+  SynFold 'macro' syn region crystalMacroBlock matchgroup=crystalMacroRegion start="\z(\\\=\){%\s*\%(\%(if\|for\|begin\)\>.*\|.*\<do\>\)\s*%}" end="\z1{%\s*end\s*%}" transparent contains=TOP
 
   if !exists('g:crystal_minlines')
     let g:crystal_minlines = 500
@@ -336,7 +337,7 @@ endif
 
 " Link attribute
 syn region crystalLinkAttrRegion      start="@\[" nextgroup=crystalLinkAttrRegionInner end="]" contains=crystalLinkAttr,crystalLinkAttrRegionInner transparent display oneline
-syn region crystalLinkAttrRegionInner start="\%(@\[\)\@<=" end="]\@=" contained contains=@crystalTop transparent display oneline
+syn region crystalLinkAttrRegionInner start="\%(@\[\)\@<=" end="]\@=" contained contains=TOP transparent display oneline
 syn match  crystalLinkAttr            "@\[" contained containedin=crystalLinkAttrRegion display
 syn match  crystalLinkAttr            "]" contained containedin=crystalLinkAttrRegion display
 
@@ -366,15 +367,16 @@ syn cluster crystalMacroGroup contains=@crystalTop
 " Cluster for Expensive Mode groups that can't appear inside macro
 " regions
 syn cluster crystalExpensive contains=
-      \ crystalMethodBlock,crystalBlock,crystalDoBlock,crystalBlockExpression,crystalCaseExpression,
-      \ crystalSelectExpression,crystalConditionalExpression
+      \ crystalMethodBlock,crystalBlock,crystalDoBlock,crystalBlockExpression,crystalRepeatExpression,
+      \ crystalCaseExpression,crystalSelectExpression,crystalConditionalExpression
 
 syn cluster crystalMacroGroup remove=@crystalExpensive
 
 " Some keywords will have to be redefined for them to be highlighted
 " properly
 syn keyword crystalMacroKeyword contained
-      \ if else elsif end for in begin do
+      \ if else elsif end for in begin do case when while until loop
+      \ rescue ensure
 
 syn cluster crystalMacroGroup add=crystalMacroKeyword
 

--- a/syntax/crystal.vim
+++ b/syntax/crystal.vim
@@ -16,7 +16,7 @@ endif
 syn iskeyword @,48-57,_,192-255,@-@
 
 " eCrystal Config
-if exists('g:main_syntax') && g:main_syntax == 'ecrystal'
+if exists('g:main_syntax') && g:main_syntax ==# 'ecrystal'
   let b:crystal_no_expensive = 1
 end
 

--- a/syntax/crystal.vim
+++ b/syntax/crystal.vim
@@ -16,7 +16,7 @@ endif
 syn iskeyword @,48-57,_,192-255,@-@
 
 " eCrystal Config
-if exists('g:main_syntax') && g:main_syntax ==# 'ecrystal'
+if exists('g:main_syntax') && g:main_syntax == 'ecrystal'
   let b:crystal_no_expensive = 1
 end
 
@@ -61,8 +61,9 @@ endfunction
 
 com! -nargs=* SynFold call s:run_syntax_fold(<q-args>)
 
-" Not-Top Cluster
-syn cluster crystalNotTop contains=@crystalExtendedStringSpecial,@crystalRegexpSpecial,@crystalDeclaration,crystalConditional,crystalExceptional,crystalMethodExceptional,crystalTodo,crystalLinkAttr
+" Top and Not-Top Clusters
+syn cluster crystalTop    contains=TOP
+syn cluster crystalNotTop contains=CONTAINED
 
 " Whitespace Errors
 if exists('g:crystal_space_errors')
@@ -78,14 +79,14 @@ endif
 if exists('g:crystal_operators')
   syn match  crystalOperator "[~!^&|*/%+-]\|\%(class\s*\)\@<!<<\|<=>\|<=\|\%(<\|\<class\s\+\u\w*\s*\)\@<!<[^<]\@=\|===\|==\|=\~\|>>\|>=\|=\@<!>\|\*\*\|\.\.\.\|\.\.\|::"
   syn match  crystalOperator "->\|-=\|/=\|\*\*=\|\*=\|&&=\|&=\|&&\|||=\||=\|||\|%=\|+=\|!\~\|!=\|//"
-  syn region crystalBracketOperator matchgroup=crystalOperator start="\%(\w[?!]\=\|[]})]\)\@<=\[\s*" end="\s*]" contains=ALLBUT,@crystalNotTop
+  syn region crystalBracketOperator matchgroup=crystalOperator start="\%(\w[?!]\=\|[]})]\)\@<=\[\s*" end="\s*]" contains=@crystalTop
 endif
 
 " Expression Substitution and Backslash Notation
 syn match crystalStringEscape "\\\\\|\\[abefnrstv]\|\\\o\{1,3}\|\\x\x\{1,2}"                            contained display
 syn match crystalStringEscape "\%(\\M-\\C-\|\\C-\\M-\|\\M-\\c\|\\c\\M-\|\\c\|\\C-\|\\M-\)\%(\\\o\{1,3}\|\\x\x\{1,2}\|\\\=\S\)" contained display
 
-syn region crystalInterpolation      matchgroup=crystalInterpolationDelim start="#{" end="}" contained contains=ALLBUT,@crystalNotTop
+syn region crystalInterpolation      matchgroup=crystalInterpolationDelim start="#{" end="}" contained contains=@crystalTop
 syn match  crystalInterpolation      "#\%(\$\|@@\=\)\w\+" display contained contains=crystalInterpolationDelim,crystalInstanceVariable,crystalClassVariable,crystalGlobalVariable,crystalPredefinedVariable
 syn match  crystalInterpolationDelim "#\ze\%(\$\|@@\=\)\w\+" display contained
 syn match  crystalInterpolation      "#\$\%(-\w\|\W\)" display contained contains=crystalInterpolationDelim,crystalPredefinedVariable,crystalInvalidVariable
@@ -226,10 +227,10 @@ SynFold '%' syn region crystalString matchgroup=crystalStringDelimiter start="%[
 SynFold '%' syn region crystalString matchgroup=crystalStringDelimiter start="%[Qx]\=|"  end="|"  skip="\\\\\|\\|"  contains=@crystalStringSpecial,crystalDelimEscape
 
 " Here Document
-syn region crystalHeredocStart matchgroup=crystalStringDelimiter start=+\%(\%(class\s*\|\%([]})"'.]\|::\)\)\_s*\|\w\)\@<!<<-\=\zs\%(\%(\h\|[^\x00-\x7F]\)\%(\w\|[^\x00-\x7F]\)*\)+ end=+$+ oneline contains=ALLBUT,@crystalNotTop
-syn region crystalHeredocStart matchgroup=crystalStringDelimiter start=+\%(\%(class\s*\|\%([]})"'.]\|::\)\)\_s*\|\w\)\@<!<<-\=\zs"\%([^"]*\)"+ end=+$+ oneline contains=ALLBUT,@crystalNotTop
-syn region crystalHeredocStart matchgroup=crystalStringDelimiter start=+\%(\%(class\s*\|\%([]})"'.]\|::\)\)\_s*\|\w\)\@<!<<-\=\zs'\%([^']*\)'+ end=+$+ oneline contains=ALLBUT,@crystalNotTop
-syn region crystalHeredocStart matchgroup=crystalStringDelimiter start=+\%(\%(class\s*\|\%([]})"'.]\|::\)\)\_s*\|\w\)\@<!<<-\=\zs`\%([^`]*\)`+ end=+$+ oneline contains=ALLBUT,@crystalNotTop
+syn region crystalHeredocStart matchgroup=crystalStringDelimiter start=+\%(\%(class\s*\|\%([]})"'.]\|::\)\)\_s*\|\w\)\@<!<<-\=\zs\%(\%(\h\|[^\x00-\x7F]\)\%(\w\|[^\x00-\x7F]\)*\)+ end=+$+ oneline contains=@crystalTop
+syn region crystalHeredocStart matchgroup=crystalStringDelimiter start=+\%(\%(class\s*\|\%([]})"'.]\|::\)\)\_s*\|\w\)\@<!<<-\=\zs"\%([^"]*\)"+ end=+$+ oneline contains=@crystalTop
+syn region crystalHeredocStart matchgroup=crystalStringDelimiter start=+\%(\%(class\s*\|\%([]})"'.]\|::\)\)\_s*\|\w\)\@<!<<-\=\zs'\%([^']*\)'+ end=+$+ oneline contains=@crystalTop
+syn region crystalHeredocStart matchgroup=crystalStringDelimiter start=+\%(\%(class\s*\|\%([]})"'.]\|::\)\)\_s*\|\w\)\@<!<<-\=\zs`\%([^`]*\)`+ end=+$+ oneline contains=@crystalTop
 
 SynFold '<<' syn region crystalString start=+\%(\%(class\|::\)\_s*\|\%([]})"'.]\)\s\|\w\)\@<!<<\z(\%(\h\|[^\x00-\x7F]\)\%(\w\|[^\x00-\x7F]\)*\)\ze\%(.*<<-\=['`"]\=\h\)\@!+hs=s+2 matchgroup=crystalStringDelimiter end=+^\z1$+ contains=crystalHeredocStart,crystalHeredoc,@crystalStringSpecial keepend
 SynFold '<<' syn region crystalString start=+\%(\%(class\|::\)\_s*\|\%([]})"'.]\)\s\|\w\)\@<!<<"\z([^"]*\)"\ze\%(.*<<-\=['`"]\=\h\)\@!+hs=s+2 matchgroup=crystalStringDelimiter end=+^\z1$+ contains=crystalHeredocStart,crystalHeredoc,@crystalStringSpecial keepend
@@ -283,28 +284,28 @@ if !exists('b:crystal_no_expensive') && !exists('g:crystal_no_expensive')
   syn match crystalMacro  "\<macro\>"  nextgroup=crystalMacroDeclaration skipwhite skipnl
   syn match crystalEnum   "\<enum\>"   nextgroup=crystalEnumDeclaration skipwhite skipnl
 
-  SynFold 'def'    syn region crystalMethodBlock start="\<\%(def\|macro\)\>" matchgroup=crystalDefine end="\%(\<\%(def\|macro\)\_s\+\)\@<!\<end\>"  contains=ALLBUT,@crystalNotTop
-  SynFold 'class'  syn region crystalBlock       start="\<class\>"           matchgroup=crystalClass  end="\<end\>"                                 contains=ALLBUT,@crystalNotTop
-  SynFold 'module' syn region crystalBlock       start="\<module\>"          matchgroup=crystalModule end="\<end\>"                                 contains=ALLBUT,@crystalNotTop
-  SynFold 'struct' syn region crystalBlock       start="\<struct\>"          matchgroup=crystalStruct end="\<end\>"                                 contains=ALLBUT,@crystalNotTop
-  SynFold 'lib'    syn region crystalBlock       start="\<lib\>"             matchgroup=crystalLib    end="\<end\>"                                 contains=ALLBUT,@crystalNotTop
-  SynFold 'enum'   syn region crystalBlock       start="\<enum\>"            matchgroup=crystalEnum   end="\<end\>"                                 contains=ALLBUT,@crystalNotTop
+  SynFold 'def'    syn region crystalMethodBlock start="\<\%(def\|macro\)\>" matchgroup=crystalDefine end="\%(\<\%(def\|macro\)\_s\+\)\@<!\<end\>"  contains=@crystalTop
+  SynFold 'class'  syn region crystalBlock       start="\<class\>"           matchgroup=crystalClass  end="\<end\>"                                 contains=@crystalTop
+  SynFold 'module' syn region crystalBlock       start="\<module\>"          matchgroup=crystalModule end="\<end\>"                                 contains=@crystalTop
+  SynFold 'struct' syn region crystalBlock       start="\<struct\>"          matchgroup=crystalStruct end="\<end\>"                                 contains=@crystalTop
+  SynFold 'lib'    syn region crystalBlock       start="\<lib\>"             matchgroup=crystalLib    end="\<end\>"                                 contains=@crystalTop
+  SynFold 'enum'   syn region crystalBlock       start="\<enum\>"            matchgroup=crystalEnum   end="\<end\>"                                 contains=@crystalTop
 
   " modifiers
   syn match crystalConditionalModifier "\<\%(if\|unless\|ifdef\)\>" display
   syn match crystalRepeatModifier      "\<\%(while\|until\)\>" display
 
-  SynFold 'do' syn region crystalDoBlock matchgroup=crystalControl start="\<do\>" end="\<end\>" contains=ALLBUT,@crystalNotTop
+  SynFold 'do' syn region crystalDoBlock matchgroup=crystalControl start="\<do\>" end="\<end\>" contains=@crystalTop
 
   " curly bracket block or hash literal
-  SynFold '{' syn region crystalCurlyBlock   matchgroup=crystalCurlyBlockDelimiter start="{"                     end="}" contains=ALLBUT,@crystalNotTop
-  SynFold '[' syn region crystalArrayLiteral matchgroup=crystalArrayDelimiter      start="\%(\w\|[\]})]\)\@<!\[" end="]" contains=ALLBUT,@crystalNotTop
+  SynFold '{' syn region crystalCurlyBlock   matchgroup=crystalCurlyBlockDelimiter start="{"                     end="}" contains=@crystalTop
+  SynFold '[' syn region crystalArrayLiteral matchgroup=crystalArrayDelimiter      start="\%(\w\|[\]})]\)\@<!\[" end="]" contains=@crystalTop
 
   " statements without 'do'
-  SynFold 'begin'  syn region crystalBlockExpression       matchgroup=crystalControl     start="\<begin\>"  end="\<end\>" contains=ALLBUT,@crystalNotTop
-  SynFold 'case'   syn region crystalCaseExpression        matchgroup=crystalConditional start="\<case\>"   end="\<end\>" contains=ALLBUT,@crystalNotTop
-  SynFold 'select' syn region crystalSelectExpression      matchgroup=crystalConditional start="\<select\>" end="\<end\>" contains=ALLBUT,@crystalNotTop
-  SynFold 'if'     syn region crystalConditionalExpression matchgroup=crystalConditional start="\%(\%(^\|\.\.\.\=\|[{:,;([<>~\*/%&^|+=-]\|\%(\<[_[:lower:]][_[:alnum:]]*\)\@<![?!]\)\s*\)\@<=\%(if\|ifdef\|unless\)\>" end="\%(\%(\%(\.\@<!\.\)\|::\)\s*\)\@<!\<end\>" contains=ALLBUT,@crystalNotTop
+  SynFold 'begin'  syn region crystalBlockExpression       matchgroup=crystalControl     start="\<begin\>"  end="\<end\>" contains=@crystalTop
+  SynFold 'case'   syn region crystalCaseExpression        matchgroup=crystalConditional start="\<case\>"   end="\<end\>" contains=@crystalTop
+  SynFold 'select' syn region crystalSelectExpression      matchgroup=crystalConditional start="\<select\>" end="\<end\>" contains=@crystalTop
+  SynFold 'if'     syn region crystalConditionalExpression matchgroup=crystalConditional start="\%(\%(^\|\.\.\.\=\|[{:,;([<>~\*/%&^|+=-]\|\%(\<[_[:lower:]][_[:alnum:]]*\)\@<![?!]\)\s*\)\@<=\%(if\|ifdef\|unless\)\>" end="\%(\%(\%(\.\@<!\.\)\|::\)\s*\)\@<!\<end\>" contains=@crystalTop
 
   syn match crystalConditional "\<\%(then\|else\|when\)\>[?!]\@!" contained containedin=crystalCaseExpression
   syn match crystalConditional "\<\%(when\|else\)\>[?!]\@!" contained containedin=crystalSelectExpression
@@ -313,7 +314,7 @@ if !exists('b:crystal_no_expensive') && !exists('g:crystal_no_expensive')
   syn match crystalExceptional       "\<\%(\%(\%(;\|^\)\s*\)\@<=rescue\|else\|ensure\)\>[?!]\@!" contained containedin=crystalBlockExpression
   syn match crystalMethodExceptional "\<\%(\%(\%(;\|^\)\s*\)\@<=rescue\|else\|ensure\)\>[?!]\@!" contained containedin=crystalMethodBlock
 
-  SynFold 'macro' syn region crystalMacroBlock matchgroup=crystalMacroRegion start="\z(\\\=\){%\s*\%(\%(if\|for\|begin\)\>.*\|.*\<do\>\)\s*%}" end="\z1{%\s*end\s*%}" transparent contains=TOP
+  SynFold 'macro' syn region crystalMacroBlock matchgroup=crystalMacroRegion start="\z(\\\=\){%\s*\%(\%(if\|for\|begin\)\>.*\|.*\<do\>\)\s*%}" end="\z1{%\s*end\s*%}" transparent contains=@crystalTop
 
   if !exists('g:crystal_minlines')
     let g:crystal_minlines = 500
@@ -335,7 +336,7 @@ endif
 
 " Link attribute
 syn region crystalLinkAttrRegion      start="@\[" nextgroup=crystalLinkAttrRegionInner end="]" contains=crystalLinkAttr,crystalLinkAttrRegionInner transparent display oneline
-syn region crystalLinkAttrRegionInner start="\%(@\[\)\@<=" end="]\@=" contained contains=ALLBUT,@crystalNotTop transparent display oneline
+syn region crystalLinkAttrRegionInner start="\%(@\[\)\@<=" end="]\@=" contained contains=@crystalTop transparent display oneline
 syn match  crystalLinkAttr            "@\[" contained containedin=crystalLinkAttrRegion display
 syn match  crystalLinkAttr            "]" contained containedin=crystalLinkAttrRegion display
 
@@ -356,8 +357,11 @@ endif
 
 " Macro
 " Note: This definition must be put after crystalNestedCurlyBraces to give higher priority
-syn region crystalMacroRegion matchgroup=crystalMacroDelim start="\\\={%" end="%}" oneline display contains=TOP,@crystalExpensive containedin=ALL
-syn region crystalMacroRegion matchgroup=crystalMacroDelim start="\\\={{" end="}}" oneline display contains=TOP,@crystalExpensive containedin=ALL
+syn region crystalMacroRegion matchgroup=crystalMacroDelim start="\\\={%" end="%}" oneline display contains=@crystalMacroGroup containedin=ALL
+syn region crystalMacroRegion matchgroup=crystalMacroDelim start="\\\={{" end="}}" oneline display contains=@crystalMacroGroup containedin=ALL
+
+" Cluster for groups that can appear inside macro expressions
+syn cluster crystalMacroGroup contains=@crystalTop
 
 " Cluster for Expensive Mode groups that can't appear inside macro
 " regions
@@ -365,16 +369,26 @@ syn cluster crystalExpensive contains=
       \ crystalMethodBlock,crystalBlock,crystalDoBlock,crystalBlockExpression,crystalCaseExpression,
       \ crystalSelectExpression,crystalConditionalExpression
 
+syn cluster crystalMacroGroup remove=@crystalExpensive
+
 " Some keywords will have to be redefined for them to be highlighted
 " properly
-syn keyword crystalMacroKeyword contained containedin=crystalMacroRegion
+syn keyword crystalMacroKeyword contained
       \ if else elsif end for in begin do
-syn cluster crystalNotTop add=crystalMacroKeyword
+
+syn cluster crystalMacroGroup add=crystalMacroKeyword
 
 " Comments and Documentation
 syn match   crystalSharpBang "\%^#!.*" display
 syn keyword crystalTodo      FIXME NOTE TODO OPTIMIZE XXX todo contained
-syn match   crystalComment   "#.*" contains=crystalSharpBang,crystalSpaceError,crystalTodo,@Spell
+
+if exists('g:main_syntax') && g:main_syntax ==# 'ecrystal'
+  " eCrystal tags can contain Crystal comments, so we need to modify the
+  " pattern for comments so that it does not consume delimiters
+  syn match crystalComment "#.*\ze\%($\|-\=%>\)" contains=crystalSharpBang,crystalSpaceError,crystalTodo,@Spell
+else
+  syn match crystalComment "#.*" contains=crystalSharpBang,crystalSpaceError,crystalTodo,@Spell
+endif
 
 SynFold '#' syn region crystalMultilineComment start="\%(\%(^\s*#.*\n\)\@<!\%(^\s*#.*\n\)\)\%(\(^\s*#.*\n\)\{1,}\)\@=" end="\%(^\s*#.*\n\)\@<=\%(^\s*#.*\n\)\%(^\s*#\)\@!" contains=crystalComment transparent keepend
 

--- a/syntax/ecrystal.vim
+++ b/syntax/ecrystal.vim
@@ -1,0 +1,33 @@
+if &syntax !~# '\<ecrystal\>' || get(b:, 'current_syntax') =~# '\<ecrystal\>'
+  finish
+endif
+
+if !exists('main_syntax')
+  let main_syntax = 'ecrystal'
+endif
+
+call ecrystal#SetSubtype()
+
+if b:ecrystal_subtype != ''
+  exec 'runtime! syntax/'.b:ecrystal_subtype.'.vim'
+  unlet! b:current_syntax
+endif
+
+syn include @crystalTop syntax/crystal.vim
+
+syn cluster ecrystalRegions contains=ecrystalControl,ecrystalRender,ecrystalComment
+
+syn region ecrystalControl matchgroup=ecrystalDelimiter start="<%%\@!-\="  end="-\=%>" display contains=@crystalTop        containedin=ALLBUT,@ecrystalRegions
+syn region ecrystalRender  matchgroup=ecrystalDelimiter start="<%%\@!-\==" end="-\=%>" display contains=@crystalTop        containedin=ALLBUT,@ecrystalRegions
+syn region ecrystalComment matchgroup=ecrystalDelimiter start="<%%\@!-\=#" end="-\=%>" display contains=crystalTodo,@Spell containedin=ALLBUT,@ecrystalRegions
+
+" Define the default highlighting.
+
+hi def link ecrystalDelimiter PreProc
+hi def link ecrystalComment   crystalComment
+
+let b:current_syntax = 'ecrystal'
+
+if main_syntax == 'ecrystal'
+  unlet main_syntax
+endif


### PR DESCRIPTION
In reference to #85.

Most of this is copied from the eRuby files in vim-ruby, but there are so many changes that I wanted to walk through everything I did to make sure that you're okay with it all.

---

## `ftdetect`

The filetype for any `*.ecr` files is set to `ecrystal`, then `ecrystal#SetSubtype` in `autoload` is used to determine the subtype. If the filename has two extensions -- like `*.html.ecr` -- the first is used as the subtype; if the filename is only `*.ecr`, then `html` is used by default. The default subtype can be changed with the `g:ecrystal_default_subtype` variable.

## `syntax`

This is mostly the same as vim-ruby.

## `ftplugin`

This is also mostly copied from vim-ruby. However, I added optional support for [auto-pairs](https://github.com/jiangmiao/auto-pairs): if the user has this plugin loaded, they will be able to use eCrystal tags with it out of the box.

Also, if the user is using [vim-endwise](https://github.com/tpope/vim-endwise), the filetype's original endwise settings will be preserved (vim-ruby doesn't do this).

Finally, if the user is using [vim-ragtag](https://github.com/tpope/vim-ragtag), it will be intialized automatically.

## `indent`

I needed helper variables and functions from `indent/crystal.vim` to make this work, so I moved them to `autoload/crystal/indent.vim` so that I could use them from the `crystal#indent` namespace.

According to my tests, my indent function is more accurate than vim-ruby's, but there are a couple of filetypes that it struggles with, such as `javascript`. This is because the contents of eCrystal tags can cause false positives in the indent functions of some filetypes, which can throw off the indentation; this problem is present in vim-ruby as well. This is something that I may try to improve in the future, but for now, it seems to work well for the most common filetypes like `html` and `yaml`.

I added a couple of options to allow users to decide whether they want the indent function to prioritize accuracy or performance in certain cases:

#### Aligning `end` tags with corresponding opener tags

In vim-ruby, `end` tags simply subtract an indent. This works for simple cases like HTML, where indentation only ever changes by one shift at a time, but can be inaccurate in other cases. Consider this YAML with eCrystal tags:

```
<% 10.times do |i| %>
  profile:
    name: test dummy <%= i %>
    description: |
      This is a test dummy.
<% end %>
```

In the above example, subtracting one indent isn't enough, so I decided to make `end` tags align with the nearest tag that starts an indent. This is more accurate and handles more edge cases, but is also slower.

This can be controlled with `g:ecrystal_align_end`; setting it to `1` enables this method while `0` causes the original (faster, less accurate) method to be used instead. By default, it is enabled for all filetypes except `html` and `xml`, where it isn't needed.

#### Indenting multiline tag bodies

In eRuby and eCrystal, it is most common for tag bodies to be one line:

```
<% if foo %>
  ...
<% end %>
```

But it is possible to have multiline tag bodies:

```
<%
  if foo
%>
  ...
<%
  end
%>
```

In fact, you can put basically any valid Crystal inside tags:

```
<% @names.each do |name| %>
  <%=
    # Different greeting based on name
    case name
    when "Alice"
      "Hi"
    when "Bob"
      "Hey"
    else
      "Hello"
    end
  %>
<% end %>
```

I made it so that Crystal indentation is properly applied to the contents of multiline tags. However, I've never seen anyone actually use multiline tags in either eRuby or eCrystal, so it's possible some people may want to turn this off just to load files a little faster: thus, this is enabled by default and can be disabled with `let g:ecrystal_indent_multiline = 0`.

#### Folding

Lastly, I have added the ability to fold blocks between control tags; this can be enabled with `let g:ecrystal_fold = 1`. For example, the following can be folded:

```
<% if foo %>
  <p>
    Hello
  </p>
<% end %>
```

---

I apologize in advance for having so much code in a single commit.