### PR TITLE
Fix miscellaneous indentation issues

### DIFF
--- a/autoload/crystal/indent.vim
+++ b/autoload/crystal/indent.vim
@@ -82,6 +82,8 @@ let g:crystal#indent#non_bracket_continuation_regex =
       \ '\|' .
       \ '\W?' .
       \ '\|' .
+      \ '\<\%(if\|unless\)\>' .
+      \ '\|' .
       \ '\%('.g:crystal#indent#sol.g:crystal#indent#crystal_type_declaration.'\h\k*\)\@<!\*' .
       \ '\)' .
       \ g:crystal#indent#eol

--- a/autoload/crystal/indent.vim
+++ b/autoload/crystal/indent.vim
@@ -78,7 +78,7 @@ lockvar g:crystal#indent#crystal_type_declaration
 " Regex that defines continuation lines, not including (, {, or [.
 let g:crystal#indent#non_bracket_continuation_regex =
       \ '\%(' .
-      \ '[\\.,:/%+\-=~<>|&]' .
+      \ '[\\.,:/%+\-=~<>|&^]' .
       \ '\|' .
       \ '\W?' .
       \ '\|' .
@@ -93,7 +93,7 @@ lockvar g:crystal#indent#non_bracket_continuation_regex
 let g:crystal#indent#bracket_continuation_regex = '%\@<!\%([({[]\)\s*\%(#.*\)\=$'
 lockvar g:crystal#indent#bracket_continuation_regex
 
-" " Regex that defines continuation lines.
+" Regex that defines continuation lines.
 let g:crystal#indent#continuation_regex =
       \ g:crystal#indent#non_bracket_continuation_regex .
       \ '\|' .

--- a/autoload/crystal/indent.vim
+++ b/autoload/crystal/indent.vim
@@ -139,23 +139,23 @@ lockvar g:crystal#indent#leading_operator_regex
 " ===================
 
 " Check if the character at lnum:col is inside a string, comment, or is ascii.
-function crystal#indent#IsInStringOrComment(lnum, col) abort
+function! crystal#indent#IsInStringOrComment(lnum, col) abort
   return synIDattr(synID(a:lnum, a:col, 1), 'name') =~# g:crystal#indent#syng_strcom
 endfunction
 
 " Check if the character at lnum:col is inside a string or character.
-function crystal#indent#IsInString(lnum, col) abort
+function! crystal#indent#IsInString(lnum, col) abort
   return synIDattr(synID(a:lnum, a:col, 1), 'name') =~# g:crystal#indent#syng_string
 endfunction
 
 " Check if the character at lnum:col is inside a string or regexp
 " delimiter
-function crystal#indent#IsInStringDelimiter(lnum, col) abort
+function! crystal#indent#IsInStringDelimiter(lnum, col) abort
   return synIDattr(synID(a:lnum, a:col, 1), 'name') =~# '\<crystal\%(StringDelimiter\|RegexpDelimiter\)\>'
 endfunction
 
 " Find line above 'lnum' that isn't empty, in a comment, or in a string.
-function crystal#indent#PrevNonBlankNonString(lnum) abort
+function! crystal#indent#PrevNonBlankNonString(lnum) abort
   let lnum = prevnonblank(a:lnum)
 
   while lnum > 0
@@ -173,7 +173,7 @@ function crystal#indent#PrevNonBlankNonString(lnum) abort
 endfunction
 
 " Find line above 'lnum' that started the continuation 'lnum' may be part of.
-function crystal#indent#GetMSL(lnum) abort
+function! crystal#indent#GetMSL(lnum) abort
   " Start on the line we're at and use its indent.
   let msl = a:lnum
   let msl_body = getline(msl)
@@ -267,7 +267,7 @@ function crystal#indent#GetMSL(lnum) abort
 endfunction
 
 " Check if line 'lnum' has more opening brackets than closing ones.
-function crystal#indent#ExtraBrackets(lnum) abort
+function! crystal#indent#ExtraBrackets(lnum) abort
   let opening = {'parentheses': [], 'braces': [], 'brackets': []}
   let closing = {'parentheses': [], 'braces': [], 'brackets': []}
 
@@ -329,7 +329,7 @@ function crystal#indent#ExtraBrackets(lnum) abort
   return [rightmost_opening, rightmost_closing]
 endfunction
 
-function crystal#indent#Match(lnum, regex) abort
+function! crystal#indent#Match(lnum, regex) abort
   let regex = '\C'.a:regex
 
   let line = getline(a:lnum)
@@ -346,7 +346,7 @@ endfunction
 
 " Locates the containing class/module/struct/enum/lib's definition line,
 " ignoring nested classes along the way.
-function crystal#indent#FindContainingClass() abort
+function! crystal#indent#FindContainingClass() abort
   let saved_position = getcurpos()
 
   while searchpair(

--- a/autoload/crystal/indent.vim
+++ b/autoload/crystal/indent.vim
@@ -139,23 +139,23 @@ lockvar g:crystal#indent#leading_operator_regex
 " ===================
 
 " Check if the character at lnum:col is inside a string, comment, or is ascii.
-function crystal#indent#IsInStringOrComment(lnum, col)
+function crystal#indent#IsInStringOrComment(lnum, col) abort
   return synIDattr(synID(a:lnum, a:col, 1), 'name') =~# g:crystal#indent#syng_strcom
 endfunction
 
 " Check if the character at lnum:col is inside a string or character.
-function crystal#indent#IsInString(lnum, col)
+function crystal#indent#IsInString(lnum, col) abort
   return synIDattr(synID(a:lnum, a:col, 1), 'name') =~# g:crystal#indent#syng_string
 endfunction
 
 " Check if the character at lnum:col is inside a string or regexp
 " delimiter
-function crystal#indent#IsInStringDelimiter(lnum, col)
+function crystal#indent#IsInStringDelimiter(lnum, col) abort
   return synIDattr(synID(a:lnum, a:col, 1), 'name') =~# '\<crystal\%(StringDelimiter\|RegexpDelimiter\)\>'
 endfunction
 
 " Find line above 'lnum' that isn't empty, in a comment, or in a string.
-function crystal#indent#PrevNonBlankNonString(lnum)
+function crystal#indent#PrevNonBlankNonString(lnum) abort
   let lnum = prevnonblank(a:lnum)
 
   while lnum > 0
@@ -173,7 +173,7 @@ function crystal#indent#PrevNonBlankNonString(lnum)
 endfunction
 
 " Find line above 'lnum' that started the continuation 'lnum' may be part of.
-function crystal#indent#GetMSL(lnum)
+function crystal#indent#GetMSL(lnum) abort
   " Start on the line we're at and use its indent.
   let msl = a:lnum
   let msl_body = getline(msl)
@@ -267,7 +267,7 @@ function crystal#indent#GetMSL(lnum)
 endfunction
 
 " Check if line 'lnum' has more opening brackets than closing ones.
-function crystal#indent#ExtraBrackets(lnum)
+function crystal#indent#ExtraBrackets(lnum) abort
   let opening = {'parentheses': [], 'braces': [], 'brackets': []}
   let closing = {'parentheses': [], 'braces': [], 'brackets': []}
 
@@ -329,7 +329,7 @@ function crystal#indent#ExtraBrackets(lnum)
   return [rightmost_opening, rightmost_closing]
 endfunction
 
-function crystal#indent#Match(lnum, regex)
+function crystal#indent#Match(lnum, regex) abort
   let regex = '\C'.a:regex
 
   let line = getline(a:lnum)
@@ -346,7 +346,7 @@ endfunction
 
 " Locates the containing class/module/struct/enum/lib's definition line,
 " ignoring nested classes along the way.
-function crystal#indent#FindContainingClass()
+function crystal#indent#FindContainingClass() abort
   let saved_position = getcurpos()
 
   while searchpair(

--- a/autoload/ecrystal.vim
+++ b/autoload/ecrystal.vim
@@ -10,7 +10,7 @@ if exists('g:ecrystal_extensions')
   call extend(s:ecrystal_extensions, g:ecrystal_extensions, 'force')
 endif
 
-function ecrystal#SetSubtype() abort
+function! ecrystal#SetSubtype() abort
   if exists('b:ecrystal_subtype')
     return
   endif

--- a/autoload/ecrystal.vim
+++ b/autoload/ecrystal.vim
@@ -10,7 +10,7 @@ if exists('g:ecrystal_extensions')
   call extend(s:ecrystal_extensions, g:ecrystal_extensions, 'force')
 endif
 
-function ecrystal#SetSubtype()
+function ecrystal#SetSubtype() abort
   if exists('b:ecrystal_subtype')
     return
   endif
@@ -19,11 +19,11 @@ function ecrystal#SetSubtype()
 
   let b:ecrystal_subtype = get(s:ecrystal_extensions, b:ecrystal_subtype, b:ecrystal_subtype)
 
-  if b:ecrystal_subtype == ''
+  if b:ecrystal_subtype ==# ''
     let b:ecrystal_subtype = get(g:, 'ecrystal_default_subtype', 'html')
   endif
 
-  if b:ecrystal_subtype != ''
+  if b:ecrystal_subtype !=# ''
     exec 'setlocal filetype=ecrystal.' . b:ecrystal_subtype
     exec 'setlocal syntax=ecrystal.' . b:ecrystal_subtype
   endif

--- a/ftplugin/ecrystal.vim
+++ b/ftplugin/ecrystal.vim
@@ -11,7 +11,7 @@ let s:match_words = ''
 
 call ecrystal#SetSubtype()
 
-if b:ecrystal_subtype != ''
+if b:ecrystal_subtype !=# ''
   exe 'runtime! ftplugin/'.b:ecrystal_subtype.'.vim ftplugin/'.b:ecrystal_subtype.'_*.vim ftplugin/'.b:ecrystal_subtype.'/*.vim'
   unlet! b:did_ftplugin
 
@@ -75,7 +75,7 @@ if exists('AutoPairsLoaded')
 endif
 
 " Load the subtype's vim-endwise settings
-if exists('loaded_endwise') && b:ecrystal_subtype != ''
+if exists('loaded_endwise') && b:ecrystal_subtype !=# ''
   exec 'doautocmd endwise FileType ' . b:ecrystal_subtype
 endif
 

--- a/indent/crystal.vim
+++ b/indent/crystal.vim
@@ -198,10 +198,14 @@ function GetCrystalIndent(...)
 
   " If the previous line ended with an "end", match that "end"s beginning's
   " indent.
-  let col = crystal#indent#Match(lnum, '\%(^\|[^.:@$]\)\<end\>\s*\%(#.*\)\=$')
+  let col = crystal#indent#Match(lnum, g:crystal#indent#end_end_regex)
   if col
     call cursor(lnum, col)
-    if searchpair(g:crystal#indent#end_start_regex, '', g:crystal#indent#end_end_regex, 'bW',
+    if searchpair(
+          \ g:crystal#indent#end_start_regex,
+          \ g:crystal#indent#end_middle_regex,
+          \ g:crystal#indent#end_end_regex,
+          \ 'bW',
           \ g:crystal#indent#skip_expr)
       let n = line('.')
       let ind = indent('.')
@@ -261,8 +265,9 @@ function GetCrystalIndent(...)
     return ind
   endif
 
-  " If the previous line ended with [*+/.,-=], but wasn't a block ending or a
-  " closing bracket, indent one extra level.
+  " If the previous line ended with an operator -- but wasn't a block
+  " ending, closing bracket, or type declaration -- indent one extra
+  " level.
   if crystal#indent#Match(lnum, g:crystal#indent#non_bracket_continuation_regex) &&
         \ !crystal#indent#Match(lnum, '^\s*\([\])}]\|end\)')
     if lnum == p_lnum

--- a/indent/ecrystal.vim
+++ b/indent/ecrystal.vim
@@ -94,6 +94,7 @@ function s:MatchAt(lnum, col, pattern)
   let pos = getcurpos()
 
   try
+    call cursor(a:lnum, a:col)
     let result = s:MatchCursor(a:pattern)
   finally
     call setpos('.', pos)
@@ -393,7 +394,7 @@ function GetEcrystalIndent() abort
       " If this is the first line after the opening delimiter, then one
       " indent is enough
       return ind
-    elseif s:MatchAt(open_tag_lnum, open_tag_col, s:ecr_comment_open)
+    elseif s:MatchAt(open_tag_lnum, open_tag_col, s:ecr_comment_open)[0]
       " eCrystal comments shouldn't be indented any further
       return ind
     else

--- a/indent/ecrystal.vim
+++ b/indent/ecrystal.vim
@@ -7,12 +7,12 @@ endif
 
 call ecrystal#SetSubtype()
 
-if b:ecrystal_subtype != ''
+if b:ecrystal_subtype !=# ''
   exec 'runtime! indent/'.b:ecrystal_subtype.'.vim'
   unlet! b:did_indent
 endif
 
-if &l:indentexpr == ''
+if &l:indentexpr ==# ''
   if &l:cindent
     let &l:indentexpr = 'cindent(v:lnum)'
   else

--- a/syntax/crystal.vim
+++ b/syntax/crystal.vim
@@ -182,8 +182,8 @@ SynFold '/' syn region crystalRegexp matchgroup=crystalRegexpDelimiter start="\%
 SynFold '/' syn region crystalRegexp matchgroup=crystalRegexpDelimiter start="\%(\h\k*\s\+\)\@<=/[ \t=/]\@!" end="/[imx]*" skip="\\\\\|\\/" contains=@crystalRegexpSpecial
 
 " Generalized Regular Expression
-SynFold '%' syn region crystalRegexp matchgroup=crystalRegexpDelimiter start="%r{"  end="}[imx]*"  skip="\\\\\|\\}"  contains=@crystalRegexpSpecial
-SynFold '%' syn region crystalRegexp matchgroup=crystalRegexpDelimiter start="%r<"  end=">[imx]*"  skip="\\\\\|\\>"  contains=@crystalRegexpSpecial,crystalNestedAngleBrackets,crystalDelimEscape
+SynFold '%' syn region crystalRegexp matchgroup=crystalRegexpDelimiter start="%r{"  end="}[imx]*"  skip="\\\\\|\\}"  contains=@crystalRegexpSpecial,crystalNestedRawCurlyBraces
+SynFold '%' syn region crystalRegexp matchgroup=crystalRegexpDelimiter start="%r<"  end=">[imx]*"  skip="\\\\\|\\>"  contains=@crystalRegexpSpecial,crystalNestedRawAngleBrackets
 SynFold '%' syn region crystalRegexp matchgroup=crystalRegexpDelimiter start="%r\[" end="\][imx]*" skip="\\\\\|\\\]" contains=@crystalRegexpSpecial
 SynFold '%' syn region crystalRegexp matchgroup=crystalRegexpDelimiter start="%r("  end=")[imx]*"  skip="\\\\\|\\)"  contains=@crystalRegexpSpecial
 SynFold '%' syn region crystalRegexp matchgroup=crystalRegexpDelimiter start="%r|"  end="|[imx]*"  skip="\\\\\|\\|"  contains=@crystalRegexpSpecial

--- a/syntax/ecrystal.vim
+++ b/syntax/ecrystal.vim
@@ -8,7 +8,7 @@ endif
 
 call ecrystal#SetSubtype()
 
-if b:ecrystal_subtype != ''
+if b:ecrystal_subtype !=# ''
   exec 'runtime! syntax/'.b:ecrystal_subtype.'.vim'
   unlet! b:current_syntax
 endif
@@ -28,6 +28,6 @@ hi def link ecrystalComment   crystalComment
 
 let b:current_syntax = 'ecrystal'
 
-if main_syntax == 'ecrystal'
+if main_syntax ==# 'ecrystal'
   unlet main_syntax
 endif


### PR DESCRIPTION
This is to address a few minor indentation issues I found.

---

```crystal
lo : UInt8*
hi : UInt8*
```

In the above, the indent function currently thinks that the pointer sign (`*`) at the end is a multiplication operator, so the second line ends up being indented as if it were a line continuation:

```crystal
lo : UInt8*
  hi : UInt8*
```

I modified the `non_bracket_continuation_regex` to check for a type declaration before the `*` (see `autoload/crystal/indent.vim:87`), so this should now be fixed.

---

Fixed an issue where sometimes `|` and `<>` delimiters of `%`-style strings would start line continuations.

---

Lastly, I fixed an issue in my previous eCrystal code that was causing eCrystal comments to not indent properly.