### PR TITLE
Add 'struct' to keywords for < operator

### DIFF
--- a/syntax/crystal.vim
+++ b/syntax/crystal.vim
@@ -77,7 +77,7 @@ endif
 
 " Operators
 if exists('g:crystal_operators')
-  syn match  crystalOperator "[~!^&|*/%+-]\|\%(class\s*\)\@<!<<\|<=>\|<=\|\%(<\|\<class\s\+\u\w*\s*\)\@<!<[^<]\@=\|===\|==\|=\~\|>>\|>=\|=\@<!>\|\*\*\|\.\.\.\|\.\.\|::"
+  syn match  crystalOperator "[~!^&|*/%+-]\|<=>\|<=\|\%(<\|\<\%(class\|struct\)\s\+\u\w*\s*\)\@<!<[^<]\@=\|===\|==\|=\~\|>>\|>=\|=\@<!>\|\*\*\|\.\.\.\|\.\.\|::"
   syn match  crystalOperator "->\|-=\|/=\|\*\*=\|\*=\|&&=\|&=\|&&\|||=\||=\|||\|%=\|+=\|!\~\|!=\|//"
   syn region crystalBracketOperator matchgroup=crystalOperator start="\%(\w[?!]\=\|[]})]\)\@<=\[\s*" end="\s*]" contains=TOP
 endif


### PR DESCRIPTION
Noticed that the `<` in `class Foo < Bar` is highlighted as a `crystalOperator`, but not the one in `struct Foo < Bar`.