### PR TITLE
Fix regression for pipe operator continuation rules

### DIFF
--- a/autoload/crystal/indent.vim
+++ b/autoload/crystal/indent.vim
@@ -122,11 +122,6 @@ lockvar g:crystal#indent#continuable_regex
 let g:crystal#indent#splat_regex = '[[,(]\s*\*\s*\%(#.*\)\=$'
 lockvar g:crystal#indent#splat_regex
 
-" Regex that defines blocks.
-" let g:crystal#indent#block_regex =
-"       \ '\%(\<do:\@!\>\|%\@1<!{\)\s*\%(|\s*(*\s*\%([*@&]\=\h\w*,\=\s*\)\%(,\s*(*\s*[*@&]\=\h\w*\s*)*\s*\)*|\)\=\s*\%(%}\)\=\s*\%(#.*\)\=$'
-" lockvar g:crystal#indent#block_regex
-
 let g:crystal#indent#block_continuation_regex = '^\s*[^])}\t ].*'.g:crystal#indent#block_regex
 lockvar g:crystal#indent#block_continuation_regex
 

--- a/autoload/crystal/indent.vim
+++ b/autoload/crystal/indent.vim
@@ -91,7 +91,7 @@ let g:crystal#indent#non_bracket_continuation_regex =
       \ '\|' .
       \ '\<\%(if\|unless\)\>' .
       \ '\|' .
-      \ '\%('.g:crystal#indent#sol.g:crystal#indent#crystal_type_declaration.'\h\k*\)\@<!\*' .
+      \ '\%('.g:crystal#indent#crystal_type_declaration.'\h\k*\)\@<!\*' .
       \ '\)' .
       \ g:crystal#indent#eol
 lockvar g:crystal#indent#non_bracket_continuation_regex

--- a/autoload/crystal/indent.vim
+++ b/autoload/crystal/indent.vim
@@ -29,6 +29,11 @@ lockvar g:crystal#indent#sol
 let g:crystal#indent#eol = '\s*\%(%}\)\=\ze\s*\%(#.*\)\=$'
 lockvar g:crystal#indent#eol
 
+" Regex that defines blocks.
+let g:crystal#indent#block_regex =
+      \ '\%(\<do\>\|%\@1<!{\)\s*\%(|[^|]*|\)\='.g:crystal#indent#eol
+lockvar g:crystal#indent#block_regex
+
 " Regex that defines the start-match for the 'end' keyword.
 " NOTE: This *should* properly match the 'do' only at the end of the
 " line
@@ -41,7 +46,7 @@ let g:crystal#indent#end_start_regex =
       \ '\<\%(if\|unless\|while\|until\|case\|begin\|for\|union\)\>' .
       \ '\)' .
       \ '\|' .
-      \ '.\{-}\zs\<do\s*\%(|.*|\)\='.g:crystal#indent#eol
+      \ g:crystal#indent#block_regex
 lockvar g:crystal#indent#end_start_regex
 
 " Regex that defines the middle-match for the 'end' keyword.
@@ -78,7 +83,9 @@ lockvar g:crystal#indent#crystal_type_declaration
 " Regex that defines continuation lines, not including (, {, or [.
 let g:crystal#indent#non_bracket_continuation_regex =
       \ '\%(' .
-      \ '[\\.,:/%+\-=~<>|&^]' .
+      \ '[\\.,:/%+\-=~<>&^]' .
+      \ '\|' .
+      \ '\%(\%(\<do\>\|%\@1<!{\)\s*|[^|]*\)\@<!|' .
       \ '\|' .
       \ '\W?' .
       \ '\|' .
@@ -116,17 +123,9 @@ let g:crystal#indent#splat_regex = '[[,(]\s*\*\s*\%(#.*\)\=$'
 lockvar g:crystal#indent#splat_regex
 
 " Regex that defines blocks.
-"
-" Note that there's a slight problem with this regex and crystal#indent#continuation_regex.
-" Code like this will be matched by both:
-"
-"   method_call do |(a, b)|
-"
-" The reason is that the pipe matches a hanging "|" operator.
-"
-let g:crystal#indent#block_regex =
-      \ '\%(\<do:\@!\>\|%\@1<!{\)\s*\%(|\s*(*\s*\%([*@&]\=\h\w*,\=\s*\)\%(,\s*(*\s*[*@&]\=\h\w*\s*)*\s*\)*|\)\=\s*\%(%}\)\=\s*\%(#.*\)\=$'
-lockvar g:crystal#indent#block_regex
+" let g:crystal#indent#block_regex =
+"       \ '\%(\<do:\@!\>\|%\@1<!{\)\s*\%(|\s*(*\s*\%([*@&]\=\h\w*,\=\s*\)\%(,\s*(*\s*[*@&]\=\h\w*\s*)*\s*\)*|\)\=\s*\%(%}\)\=\s*\%(#.*\)\=$'
+" lockvar g:crystal#indent#block_regex
 
 let g:crystal#indent#block_continuation_regex = '^\s*[^])}\t ].*'.g:crystal#indent#block_regex
 lockvar g:crystal#indent#block_continuation_regex

--- a/indent/crystal.vim
+++ b/indent/crystal.vim
@@ -168,7 +168,7 @@ function GetCrystalIndent(...)
   "
   " If it contained hanging closing brackets, find the rightmost one, find its
   " match and indent according to that.
-  if line =~# '[[({]' || line =~# '[])}]\s*\%(#.*\)\=$'
+  if line =~# '[[({]' || line =~# '[])]\s*\%(#.*\)\=$'
     let [opening, closing] = crystal#indent#ExtraBrackets(lnum)
 
     if opening.pos != -1


### PR DESCRIPTION
This is to fix another regression that was affecting line continuation rules for `|`. Specifically, I was not properly checking to see if it was part of a `do |...|` or `{ |...|` before allowing it to be recognized as a pipe operator. This was causing the following

```crystal
(1..10).each do |i|
  (1..10).each do |j|
    something
  end
end
```

to be indented like this:

```crystal
(1..10).each do |i|
  (1..10).each do |j|
  something
end
end
```