### PR TITLE
Move indentation settings to indent/crystal.vim

### DIFF
--- a/indent/crystal.vim
+++ b/indent/crystal.vim
@@ -8,6 +8,16 @@ endif
 
 let b:did_indent = 1
 
+if !exists('g:crystal_indent_assignment_style')
+  " Possible values: 'variable', 'hanging'
+  let g:crystal_indent_assignment_style = 'hanging'
+endif
+
+if !exists('g:crystal_indent_block_style')
+  " Possible values: 'expression', 'do'
+  let g:crystal_indent_block_style = 'expression'
+endif
+
 setlocal nosmartindent
 
 " Now, set up our indentation expression and keys that trigger it.

--- a/plugin/crystal.vim
+++ b/plugin/crystal.vim
@@ -17,16 +17,4 @@ else
   let g:syntastic_extra_filetypes = ['crystal']
 end
 
-" Indent configuration variables:
-
-if !exists('g:crystal_indent_assignment_style')
-  " Possible values: 'variable', 'hanging'
-  let g:crystal_indent_assignment_style = 'hanging'
-endif
-
-if !exists('g:crystal_indent_block_style')
-  " Possible values: 'expression', 'do'
-  let g:crystal_indent_block_style = 'expression'
-endif
-
 " vim: sw=2 sts=2 et:


### PR DESCRIPTION
Moving indentation settings from `plugin/crystal.vim` to `indent/crystal.vim` ensures indentation is completely self-contained. It also fixes https://github.com/sheerun/vim-polyglot/issues/651 because vim-polyglot does not load the `plugin` directory.

This change is also inline with how [Ruby does it](https://github.com/vim-ruby/vim-ruby/blob/master/indent/ruby.vim#L17-L35).