### PR TITLE
Crystal (no longer?) supports declaring types with `type`

### DIFF
--- a/syntax/crystal.vim
+++ b/syntax/crystal.vim
@@ -268,7 +268,7 @@ if !exists('b:crystal_no_expensive') && !exists('g:crystal_no_expensive')
   syn match crystalDefine     "\<alias\>"      nextgroup=crystalAliasDeclaration skipwhite skipnl
   syn match crystalDefine     "\<def\>"        nextgroup=crystalMethodDeclaration skipwhite skipnl
   syn match crystalDefine     "\<fun\>"        nextgroup=crystalFunctionDeclaration skipwhite skipnl
-  syn match crystalDefine     "\<\%(type\|alias\)\>\%(\s*\h\w*\s*=\)\@=" nextgroup=crystalTypeDeclaration skipwhite skipnl
+  syn match crystalDefine     "\<alias\>\%(\s*\h\w*\s*=\)\@=" nextgroup=crystalTypeDeclaration skipwhite skipnl
   syn match crystalClass      "\<class\>"      nextgroup=crystalClassDeclaration skipwhite skipnl
   syn match crystalModule     "\<module\>"     nextgroup=crystalModuleDeclaration skipwhite skipnl
   syn match crystalStruct     "\<struct\>"     nextgroup=crystalStructDeclaration skipwhite skipnl


### PR DESCRIPTION
Nowadays, `type A = B` results in being told we're not allowed to dynamically declare constants. Perhaps `type` used to be an alias for `alias`?